### PR TITLE
기능(seo): 기본 SEO 설정

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,23 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+		<script type="application/ld+json">
+			{
+				"@context": "https://schema.org",
+				"@type": "WebApplication",
+				"name": "FANTAZZK",
+				"url": "https://fantazzk-rho.vercel.app",
+				"description": "치지직 대회 모의 드래프트/경매 시뮬레이터. 자낳대 모의경매, 치지직 드래프트를 체험하세요.",
+				"applicationCategory": "GameApplication",
+				"operatingSystem": "Web",
+				"offers": {
+					"@type": "Offer",
+					"price": "0",
+					"priceCurrency": "KRW"
+				},
+				"inLanguage": "ko"
+			}
+		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,36 @@
 	import favicon from '$lib/assets/favicon.svg';
 
 	let { children } = $props();
+
+	const SITE_NAME = 'FANTAZZK';
+	const SITE_URL = 'https://fantazzk-rho.vercel.app';
+	const DEFAULT_TITLE = 'FANTAZZK — 치지직 대회 모의 드래프트/경매 시뮬레이터';
+	const DEFAULT_DESCRIPTION =
+		'자낳대 모의경매, 치지직 드래프트를 직접 체험하세요. 나만의 드림팀을 경매하고 결과를 공유하는 모의 드래프트 시뮬레이터.';
 </script>
 
-<svelte:head><link rel="icon" href={favicon} /></svelte:head>
+<svelte:head>
+	<link rel="icon" href={favicon} />
+
+	<!-- 기본 메타 -->
+	<meta name="description" content={DEFAULT_DESCRIPTION} />
+
+	<!-- Open Graph -->
+	<meta property="og:site_name" content={SITE_NAME} />
+	<meta property="og:type" content="website" />
+	<meta property="og:locale" content="ko_KR" />
+	<meta property="og:url" content={SITE_URL} />
+	<meta property="og:title" content={DEFAULT_TITLE} />
+	<meta property="og:description" content={DEFAULT_DESCRIPTION} />
+	<!-- TODO: og:image — 로고(#17) 완성 후 기본 OG 이미지(1200x630) 추가 -->
+	<!-- <meta property="og:image" content="{SITE_URL}/og-default.png" /> -->
+	<!-- <meta property="og:image:width" content="1200" /> -->
+	<!-- <meta property="og:image:height" content="630" /> -->
+
+	<!-- Twitter Card -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={DEFAULT_TITLE} />
+	<meta name="twitter:description" content={DEFAULT_DESCRIPTION} />
+	<!-- TODO: twitter:image — og:image와 동일, 로고(#17) 완성 후 추가 -->
+</svelte:head>
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,7 +54,16 @@
 </script>
 
 <svelte:head>
-	<title>Fantazzk</title>
+	<title>FANTAZZK — 자낳대, 치지직컵 모의경매 & 드래프트</title>
+	<meta
+		name="description"
+		content="자낳대 모의경매, 치지직 드래프트를 직접 체험하세요. 나만의 드림팀을 경매하고 결과를 공유하는 모의 드래프트 시뮬레이터."
+	/>
+	<meta property="og:title" content="FANTAZZK — 자낳대, 치지직컵 모의경매 & 드래프트" />
+	<meta
+		property="og:description"
+		content="자낳대 모의경매, 치지직 드래프트를 직접 체험하세요. 나만의 드림팀을 경매하고 결과를 공유하는 모의 드래프트 시뮬레이터."
+	/>
 </svelte:head>
 
 <div class="flex h-screen bg-bg-primary">
@@ -89,26 +98,15 @@
 		<section class="flex h-[260px] items-center gap-10 border border-gray-50 p-8">
 			<div class="flex flex-1 flex-col justify-center gap-4">
 				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
-					FEATURED TOURNAMENT
+					모의 드래프트 & 경매 시뮬레이터
 				</span>
-				<h1 class="font-heading text-4xl font-bold text-gray-50">Chzzk 챌린저스 시즌 3</h1>
+				<h1 class="font-heading text-4xl font-bold text-gray-50">나만의 드림팀, 직접 경매하세요</h1>
 				<p class="font-mono text-[13px] leading-relaxed text-muted">
-					최고의 스트리머들이 펼치는 리그 오브 레전드 토너먼트.<br />
-					나만의 드림팀을 구성하세요.
+					자낳대 모의경매부터 치지직 드래프트까지.<br />
+					좋아하는 스트리머로 팀을 짜고, 결과를 공유하세요.
 				</p>
-				<div class="flex gap-6">
-					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						GAME: LOL
-					</span>
-					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						TEAMS: 8
-					</span>
-					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						USED: 1.2K
-					</span>
-				</div>
 				<div>
-					<Button variant="PRIMARY" size="MD">QUICK START</Button>
+					<Button variant="PRIMARY" size="MD">지금 시작하기</Button>
 				</div>
 			</div>
 			<div class="h-full w-[280px] rounded-sm bg-gray-800"></div>

--- a/src/routes/auction/[id]/+page.svelte
+++ b/src/routes/auction/[id]/+page.svelte
@@ -30,7 +30,8 @@
 </script>
 
 <svelte:head>
-	<title>경매방 | Fantazzk</title>
+	<title>경매 진행 중 | FANTAZZK</title>
+	<meta name="robots" content="noindex" />
 </svelte:head>
 
 <div class="flex h-screen flex-col bg-bg-primary">

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -120,7 +120,8 @@
 </script>
 
 <svelte:head>
-	<title>드래프트방 | Fantazzk</title>
+	<title>드래프트 진행 중 | FANTAZZK</title>
+	<meta name="robots" content="noindex" />
 </svelte:head>
 
 <div class="flex h-screen flex-col bg-bg-primary">

--- a/src/routes/lobby/[id]/+page.svelte
+++ b/src/routes/lobby/[id]/+page.svelte
@@ -5,7 +5,8 @@
         방장이 시작/일시정지를 제어한다. (Feature: Multiplayer)
 -->
 <svelte:head>
-	<title>로비 | Fantazzk</title>
+	<title>대기실 | FANTAZZK</title>
+	<meta name="robots" content="noindex" />
 </svelte:head>
 
 <h1>멀티플레이어 로비</h1>

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -5,7 +5,9 @@
         OG 태그로 디시/카톡 링크 미리보기 지원. (Feature: Result Share Card)
 -->
 <svelte:head>
-	<title>결과 | Fantazzk</title>
+	<title>결과 | FANTAZZK</title>
+	<!-- TODO: SSR load 함수에서 결과 데이터를 받아 동적 title/description/OG 태그로 교체 (#14 Phase 2) -->
+	<!-- TODO: og:image — /api/og/result/[id] Vercel OG 이미지 엔드포인트 구현 (#14 Phase 3) -->
 </svelte:head>
 
 <h1>결과 공유 카드</h1>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,33 @@
+import type { RequestHandler } from './$types';
+
+const SITE_URL = 'https://fantazzk-rho.vercel.app';
+
+// TODO: Phase 2 — Supabase 연동 후 공개 결과 페이지 URL을 DB에서 조회하여 동적 추가
+const staticPages = [
+	{ loc: '/', changefreq: 'daily', priority: '1.0' },
+	{ loc: '/templates/create', changefreq: 'monthly', priority: '0.6' }
+];
+
+export const GET: RequestHandler = async () => {
+	const urls = staticPages
+		.map(
+			(page) => `
+  <url>
+    <loc>${SITE_URL}${page.loc}</loc>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+  </url>`
+		)
+		.join('');
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}
+</urlset>`;
+
+	return new Response(xml.trim(), {
+		headers: {
+			'Content-Type': 'application/xml',
+			'Cache-Control': 'max-age=3600'
+		}
+	});
+};

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -3,7 +3,11 @@
 </script>
 
 <svelte:head>
-	<title>템플릿 생성 | Fantazzk</title>
+	<title>템플릿 만들기 | FANTAZZK</title>
+	<meta
+		name="description"
+		content="나만의 경매/드래프트 템플릿을 만들어 보세요. 팀 수, 선수 풀, 포인트를 자유롭게 설정하세요."
+	/>
 </svelte:head>
 
 <div class="flex h-screen bg-bg-primary">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,7 @@
-# allow crawling everything by default
 User-agent: *
-Disallow:
+Allow: /
+Disallow: /lobby/
+Disallow: /auction/
+Disallow: /draft/
+
+Sitemap: https://fantazzk-rho.vercel.app/sitemap.xml


### PR DESCRIPTION
## 변경 사항

- 전역 OG / Twitter Card / JSON-LD (WebApplication) 메타태그 추가
- 페이지별 title · description 설정, 세션 페이지 noindex 처리
- `robots.txt` 세션 경로 차단, `sitemap.xml` 정적 생성
- 홈 히어로 섹션 랜딩 카피를 검색 키워드 기반으로 교체

## 미완료 (TODO)

- [ ] `og:image` / `twitter:image` — 로고(#17) 완성 후 추가
- [ ] 결과 페이지 동적 OG — Supabase(#7) + 결과 UI(#5) 완료 후
- [ ] sitemap 동적 확장 — DB 연동 후 결과 페이지 URL 포함

## 테스트

- [x] `pnpm check` 통과 (0 에러)
- [x] `pnpm build` 성공
- [ ] 배포 후 OG 미리보기 확인 (카카오톡, 디스코드)

Closes #14 (Phase 1)