### PR TITLE
기능(nav): 사이드바 네비게이션 href 연결 (#35)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,16 +61,23 @@
 	<!-- Sidebar -->
 	<Sidebar logo="CD">
 		{#snippet nav()}
-			<button
+			<a
+				href="/"
 				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8"
 				aria-label="대시보드"
 				aria-current="page"
+				title="대시보드"
 			>
 				<Icon name="layout-grid" color="#0A0A0A" />
-			</button>
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="템플릿">
+			</a>
+			<a
+				href="/templates/create"
+				class="flex h-12 w-12 items-center justify-center"
+				aria-label="템플릿"
+				title="템플릿 만들기"
+			>
 				<Icon name="file-text" color="#0A0A0A" />
-			</button>
+			</a>
 			<button class="flex h-12 w-12 items-center justify-center" aria-label="트렌드">
 				<Icon name="trending-up" color="#0A0A0A" />
 			</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -73,7 +73,7 @@
 			<a
 				href="/templates/create"
 				class="flex h-12 w-12 items-center justify-center"
-				aria-label="템플릿"
+				aria-label="템플릿 만들기"
 				title="템플릿 만들기"
 			>
 				<Icon name="file-text" color="#0A0A0A" />

--- a/src/routes/lobby/[id]/+page.svelte
+++ b/src/routes/lobby/[id]/+page.svelte
@@ -57,13 +57,14 @@
 	<!-- Sidebar -->
 	<Sidebar logo="BD">
 		{#snippet nav()}
-			<button
-				type="button"
+			<a
+				href="/"
 				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8 text-bg-primary"
 				aria-label="대시보드"
+				title="대시보드"
 			>
 				<Icon name="layout-grid" />
-			</button>
+			</a>
 			<button
 				type="button"
 				class="flex h-12 w-12 items-center justify-center text-bg-primary"

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -10,16 +10,23 @@
 	<!-- Sidebar -->
 	<Sidebar logo="MD">
 		{#snippet nav()}
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="대시보드">
+			<a
+				href="/"
+				class="flex h-12 w-12 items-center justify-center"
+				aria-label="대시보드"
+				title="대시보드"
+			>
 				<Icon name="layout-grid" color="#0A0A0A" />
-			</button>
-			<button
+			</a>
+			<a
+				href="/templates/create"
 				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8"
 				aria-label="템플릿"
 				aria-current="page"
+				title="템플릿 만들기"
 			>
 				<Icon name="file-text" color="#0A0A0A" />
-			</button>
+			</a>
 			<button class="flex h-12 w-12 items-center justify-center" aria-label="트렌드">
 				<Icon name="trending-up" color="#0A0A0A" />
 			</button>

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -21,7 +21,7 @@
 			<a
 				href="/templates/create"
 				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8"
-				aria-label="템플릿"
+				aria-label="템플릿 만들기"
 				aria-current="page"
 				title="템플릿 만들기"
 			>


### PR DESCRIPTION
## Summary

- 홈, 로비, 템플릿 생성 3개 페이지의 사이드바 네비게이션 아이콘 중 대시보드(`/`)와 템플릿(`/templates/create`)을 `<button>`에서 `<a>`로 전환하고 `href` 연결
- 호버 시 이동 대상을 표시하는 `title` 속성 추가
- 라우트가 없는 Trends, Users 등은 `<button>`으로 유지

Closes #35