### PR TITLE
기능(template): 템플릿 생성 폼 동작 구현 (#41)

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -11,7 +11,8 @@
 		| 'download'
 		| 'link'
 		| 'refresh-cw'
-		| 'play';
+		| 'play'
+		| 'info';
 
 	interface Props {
 		name: IconName;
@@ -92,5 +93,9 @@
 		<path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14" />
 	{:else if name === 'play'}
 		<polygon points="5 3 19 12 5 21 5 3" />
+	{:else if name === 'info'}
+		<circle cx="12" cy="12" r="10" />
+		<line x1="12" y1="16" x2="12" y2="12" />
+		<line x1="12" y1="8" x2="12.01" y2="8" />
 	{/if}
 </svg>

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -2,7 +2,7 @@
 	interface Props {
 		checked: boolean;
 		onchange?: (checked: boolean) => void;
-		label?: string;
+		label: string;
 	}
 
 	let { checked = $bindable(), onchange, label }: Props = $props();

--- a/src/lib/components/Toggle.svelte
+++ b/src/lib/components/Toggle.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	interface Props {
+		checked: boolean;
+		onchange?: (checked: boolean) => void;
+		label?: string;
+	}
+
+	let { checked = $bindable(), onchange, label }: Props = $props();
+
+	function toggle() {
+		checked = !checked;
+		onchange?.(checked);
+	}
+</script>
+
+<button
+	type="button"
+	role="switch"
+	aria-checked={checked}
+	aria-label={label}
+	onclick={toggle}
+	class="flex h-6 w-10 items-center rounded-full px-0.5 {checked ? 'bg-accent' : 'bg-gray-700'}"
+>
+	<div class="h-5 w-5 rounded-full bg-bg-primary {checked ? 'ml-auto' : ''}"></div>
+</button>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,3 +8,4 @@ export { default as ResultListItem } from './ResultListItem.svelte';
 export { default as FormField } from './FormField.svelte';
 export { default as Sidebar } from './Sidebar.svelte';
 export { default as ThemePicker } from './ThemePicker.svelte';
+export { default as Toggle } from './Toggle.svelte';

--- a/src/lib/domain/template/__tests__/template.test.ts
+++ b/src/lib/domain/template/__tests__/template.test.ts
@@ -8,20 +8,18 @@ const defaultParams: TemplateParams = {
 	gameType: 'LEAGUE_OF_LEGENDS',
 	creatorId: 'user-1',
 	mode: 'AUCTION',
-	matchFormat: 'BO3',
 	pickBanTime: 90,
-	restrictions: '욕설/도배 즉시 실격',
 	playerPool: [
-		{ name: 'Faker', position: 'MID' },
-		{ name: 'Zeus', position: 'TOP' },
-		{ name: 'Oner', position: 'JG' },
-		{ name: 'Gumayusi', position: 'ADC' },
-		{ name: 'Keria', position: 'SUP' }
+		{ name: 'Faker', position: 'MID', tier: 'S+' },
+		{ name: 'Zeus', position: 'TOP', tier: 'S' },
+		{ name: 'Oner', position: 'JG', tier: 'A+' },
+		{ name: 'Gumayusi', position: 'ADC', tier: 'A' },
+		{ name: 'Keria', position: 'SUP', tier: 'S' }
 	],
-	tierBalancing: 'AUTO',
-	captainSelectMode: 'VOTE',
 	captainsNeeded: 2,
-	isPublic: true
+	creatorAsCaptain: true,
+	totalPoints: 1000,
+	minBidUnit: 10
 };
 
 describe('Template', () => {
@@ -38,5 +36,94 @@ describe('Template', () => {
 	it('usageCount 미지정 시 0으로 초기화된다', () => {
 		const template = new Template(defaultParams);
 		expect(template.usageCount).toBe(0);
+	});
+});
+
+describe('Template.getCompletionRate', () => {
+	const base = {
+		name: '',
+		gameType: 'LEAGUE_OF_LEGENDS' as const,
+		pickBanTime: 0,
+		mode: 'DRAFT' as const,
+		players: [] as { name: string }[],
+		captainsNeeded: 0
+	};
+
+	it('모든 필드가 비어있으면 전체 0%', () => {
+		const result = Template.getCompletionRate(base);
+		expect(result.percent).toBe(0);
+		expect(result.steps).toEqual([0, 0, 0, 0]);
+	});
+
+	it('모든 필드가 채워지면 전체 100%', () => {
+		const result = Template.getCompletionRate({
+			...base,
+			name: '자낳대 시즌1',
+			pickBanTime: 30,
+			players: [{ name: 'Faker' }, { name: 'Zeus' }],
+			captainsNeeded: 2
+		});
+		expect(result.percent).toBe(100);
+		expect(result.steps).toEqual([100, 100, 100, 100]);
+	});
+
+	it('1단계 — 이름만 입력하고 게임종목이 있으면 100%', () => {
+		const result = Template.getCompletionRate({ ...base, name: '대회' });
+		expect(result.steps[0]).toBe(100);
+	});
+
+	it('2단계 드래프트 — 픽밴시간만 있으면 100%', () => {
+		const result = Template.getCompletionRate({ ...base, pickBanTime: 30 });
+		expect(result.steps[1]).toBe(100);
+	});
+
+	it('2단계 경매 — 3개 필드 중 1개만 채우면 33%', () => {
+		const result = Template.getCompletionRate({
+			...base,
+			mode: 'AUCTION',
+			pickBanTime: 30,
+			totalPoints: 0,
+			minBid: 0
+		});
+		expect(result.steps[1]).toBe(33);
+	});
+
+	it('2단계 경매 — 3개 필드 모두 채우면 100%', () => {
+		const result = Template.getCompletionRate({
+			...base,
+			mode: 'AUCTION',
+			pickBanTime: 30,
+			totalPoints: 1000,
+			minBid: 10
+		});
+		expect(result.steps[1]).toBe(100);
+	});
+
+	it('3단계 — 선수가 없으면 0%', () => {
+		const result = Template.getCompletionRate(base);
+		expect(result.steps[2]).toBe(0);
+	});
+
+	it('3단계 — 선수 3명 중 2명 이름 입력이면 67%', () => {
+		const result = Template.getCompletionRate({
+			...base,
+			players: [{ name: 'A' }, { name: 'B' }, { name: '' }]
+		});
+		expect(result.steps[2]).toBe(67);
+	});
+
+	it('4단계 — 감독 수가 0이면 0%, 1 이상이면 100%', () => {
+		expect(Template.getCompletionRate(base).steps[3]).toBe(0);
+		expect(Template.getCompletionRate({ ...base, captainsNeeded: 2 }).steps[3]).toBe(100);
+	});
+
+	it('전체 percent는 4단계 평균이다', () => {
+		const result = Template.getCompletionRate({
+			...base,
+			name: '대회',
+			captainsNeeded: 2
+		});
+		// step1=100, step2=0, step3=0, step4=100 → 평균 50
+		expect(result.percent).toBe(50);
 	});
 });

--- a/src/lib/domain/template/index.ts
+++ b/src/lib/domain/template/index.ts
@@ -2,10 +2,9 @@ export { Template } from './template.ts';
 export { Player } from './player.ts';
 export type {
 	GameType,
-	TemplateMode,
-	MatchFormat,
-	TierBalancing,
-	CaptainSelectMode,
+	TemplateModeType,
+	DraftModeType,
+	TierType,
 	PlayerParams,
 	TemplateParams
 } from './types.ts';

--- a/src/lib/domain/template/player.ts
+++ b/src/lib/domain/template/player.ts
@@ -1,11 +1,13 @@
-import type { PlayerParams } from './types.ts';
+import type { PlayerParams, TierType } from './types.ts';
 
 export class Player {
 	readonly name: string;
 	readonly position: string;
+	readonly tier?: TierType | undefined;
 
 	constructor(params: PlayerParams) {
 		this.name = params.name;
 		this.position = params.position;
+		this.tier = params.tier;
 	}
 }

--- a/src/lib/domain/template/template.ts
+++ b/src/lib/domain/template/template.ts
@@ -1,11 +1,4 @@
-import type {
-	GameType,
-	TemplateMode,
-	MatchFormat,
-	TierBalancing,
-	CaptainSelectMode,
-	TemplateParams
-} from './types.ts';
+import type { GameType, TemplateModeType, DraftModeType, TemplateParams } from './types.ts';
 import { Player } from './player.ts';
 
 export class Template {
@@ -13,19 +6,19 @@ export class Template {
 	readonly name: string;
 	readonly gameType: GameType;
 	readonly creatorId: string;
-	readonly mode: TemplateMode;
-
-	readonly matchFormat: MatchFormat;
+	readonly mode: TemplateModeType;
 	readonly pickBanTime: number;
-	readonly restrictions: string;
-
 	readonly playerPool: readonly Player[];
-	readonly tierBalancing: TierBalancing;
-
-	readonly captainSelectMode: CaptainSelectMode;
 	readonly captainsNeeded: number;
+	readonly creatorAsCaptain: boolean;
 
-	readonly isPublic: boolean;
+	/** 경매 전용 */
+	readonly totalPoints?: number | undefined;
+	readonly minBidUnit?: number | undefined;
+
+	/** 드래프트 전용 */
+	readonly draftMode?: DraftModeType | undefined;
+
 	readonly usageCount: number;
 	readonly createdAt: Date;
 	readonly updatedAt: Date;
@@ -36,14 +29,13 @@ export class Template {
 		this.gameType = params.gameType;
 		this.creatorId = params.creatorId;
 		this.mode = params.mode;
-		this.matchFormat = params.matchFormat;
 		this.pickBanTime = params.pickBanTime;
-		this.restrictions = params.restrictions;
 		this.playerPool = params.playerPool.map((p) => new Player(p));
-		this.tierBalancing = params.tierBalancing;
-		this.captainSelectMode = params.captainSelectMode;
 		this.captainsNeeded = params.captainsNeeded;
-		this.isPublic = params.isPublic;
+		this.creatorAsCaptain = params.creatorAsCaptain;
+		this.totalPoints = params.totalPoints;
+		this.minBidUnit = params.minBidUnit;
+		this.draftMode = params.draftMode;
 		this.usageCount = params.usageCount ?? 0;
 		this.createdAt = params.createdAt ?? new Date();
 		this.updatedAt = params.updatedAt ?? new Date();
@@ -51,5 +43,42 @@ export class Template {
 
 	get playerCount(): number {
 		return this.playerPool.length;
+	}
+
+	static getCompletionRate(data: {
+		name: string;
+		gameType: GameType;
+		pickBanTime: number;
+		mode: TemplateModeType;
+		totalPoints?: number;
+		minBid?: number;
+		players: readonly { name: string }[];
+		captainsNeeded: number;
+	}): { steps: number[]; percent: number } {
+		const step1 = data.name.trim() && data.gameType ? 100 : data.name.trim() ? 50 : 0;
+
+		let step2Fields = 0;
+		let step2Total = 1;
+		if (data.pickBanTime > 0) step2Fields++;
+		if (data.mode === 'AUCTION') {
+			step2Total = 3;
+			if ((data.totalPoints ?? 0) > 0) step2Fields++;
+			if ((data.minBid ?? 0) > 0) step2Fields++;
+		}
+		const step2 = Math.round((step2Fields / step2Total) * 100);
+
+		const step3 =
+			data.players.length === 0
+				? 0
+				: Math.round(
+						(data.players.filter((p) => p.name.trim()).length / data.players.length) * 100
+					);
+
+		const step4 = data.captainsNeeded > 0 ? 100 : 0;
+
+		const steps = [step1, step2, step3, step4];
+		const percent = Math.round(steps.reduce((a, b) => a + b, 0) / steps.length);
+
+		return { steps, percent };
 	}
 }

--- a/src/lib/domain/template/types.ts
+++ b/src/lib/domain/template/types.ts
@@ -1,21 +1,19 @@
 /** 게임 종목 */
-export type GameType = 'LEAGUE_OF_LEGENDS' | 'VALORANT' | 'PUBG';
+export type GameType = 'LEAGUE_OF_LEGENDS' | 'VALORANT' | 'OVERWATCH_2' | 'BATTLEGROUNDS';
 
 /** 팀 구성 방식: 경매(포인트 입찰) 또는 드래프트(순차 픽) */
-export type TemplateMode = 'AUCTION' | 'DRAFT';
+export type TemplateModeType = 'AUCTION' | 'DRAFT';
 
-/** 대회 매치 포맷 */
-export type MatchFormat = 'BO1' | 'BO3' | 'BO5';
+/** 드래프트 방식 */
+export type DraftModeType = 'SEQUENTIAL' | 'SNAKE';
 
-/** 티어 밸런싱 방식 */
-export type TierBalancing = 'AUTO' | 'MANUAL';
-
-/** 팀장 선출 방식 */
-export type CaptainSelectMode = 'VOTE' | 'ADMIN_PICK';
+/** 선수 등급 */
+export type TierType = 'S+' | 'S' | 'A+' | 'A' | 'B+' | 'B' | 'C+' | 'C' | 'D+' | 'D';
 
 export interface PlayerParams {
 	readonly name: string;
 	readonly position: string;
+	readonly tier?: TierType;
 }
 
 export interface TemplateParams {
@@ -23,15 +21,19 @@ export interface TemplateParams {
 	readonly name: string;
 	readonly gameType: GameType;
 	readonly creatorId: string;
-	readonly mode: TemplateMode;
-	readonly matchFormat: MatchFormat;
+	readonly mode: TemplateModeType;
 	readonly pickBanTime: number;
-	readonly restrictions: string;
 	readonly playerPool: readonly PlayerParams[];
-	readonly tierBalancing: TierBalancing;
-	readonly captainSelectMode: CaptainSelectMode;
 	readonly captainsNeeded: number;
-	readonly isPublic: boolean;
+	readonly creatorAsCaptain: boolean;
+
+	/** 경매 전용 */
+	readonly totalPoints?: number;
+	readonly minBidUnit?: number;
+
+	/** 드래프트 전용 */
+	readonly draftMode?: DraftModeType;
+
 	readonly usageCount?: number;
 	readonly createdAt?: Date;
 	readonly updatedAt?: Date;

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -81,6 +81,14 @@
 
 /* ─── Global Styles ─── */
 
+*,
+*::before,
+*::after {
+	transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+	transition-duration: 150ms;
+	transition-timing-function: ease-in-out;
+}
+
 html {
 	color-scheme: dark;
 }

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
 	import { Template } from '$lib/domain/template';
-	import type { GameType, TemplateModeType, DraftModeType } from '$lib/domain/template/types';
+	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
 
 	// --- State ---
 	let name = $state('');
@@ -19,8 +19,7 @@
 	let stepRefs = $state<(HTMLElement | null)[]>([null, null, null, null]);
 
 	// --- 선수 관련 ---
-	const TIERS = ['S+', 'S', 'A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D'] as const;
-	type TierType = (typeof TIERS)[number];
+	const TIERS: TierType[] = ['S+', 'S', 'A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D'];
 
 	interface PlayerEntry {
 		name: string;
@@ -159,7 +158,14 @@
 						<span class="font-mono text-xs font-semibold text-muted">진행률</span>
 						<span class="font-mono text-xs font-semibold text-accent">{completion.percent}%</span>
 					</div>
-					<div class="h-1 w-full rounded-full bg-gray-700">
+					<div
+						class="h-1 w-full rounded-full bg-gray-700"
+						role="progressbar"
+						aria-valuenow={completion.percent}
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-label="템플릿 완성도"
+					>
 						<div class="h-full rounded-full bg-accent" style="width: {completion.percent}%"></div>
 					</div>
 				</div>
@@ -217,13 +223,13 @@
 								? 'border-accent'
 								: 'border-gray-700'}"
 						>
-							<span
+							<h2
 								class="font-mono text-sm font-bold tracking-wider {activeStep === 0
 									? 'text-accent'
 									: 'text-gray-50'}"
 							>
 								1단계 기본 정보
-							</span>
+							</h2>
 							<div class="flex flex-col gap-2">
 								<label for="name" class="font-mono text-xs font-semibold tracking-[2px] text-muted">
 									대회 이름
@@ -240,10 +246,12 @@
 								<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
 									게임 종목
 								</span>
-								<div class="flex gap-2.5">
+								<div class="flex gap-2.5" role="radiogroup" aria-label="게임 종목">
 									{#each GAME_OPTIONS as opt}
 										<button
 											type="button"
+											role="radio"
+											aria-checked={gameType === opt.value}
 											onclick={() => setGameType(opt.value)}
 											class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {gameType ===
 											opt.value
@@ -264,21 +272,23 @@
 								? 'border-accent'
 								: 'border-gray-700'}"
 						>
-							<span
+							<h2
 								class="font-mono text-sm font-bold tracking-wider {activeStep === 1
 									? 'text-accent'
 									: 'text-gray-50'}"
 							>
 								2단계 규칙
-							</span>
+							</h2>
 							<div class="flex flex-col gap-2">
 								<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
 									진행 방식
 								</span>
-								<div class="flex gap-2.5">
+								<div class="flex gap-2.5" role="radiogroup" aria-label="진행 방식">
 									{#each MODE_OPTIONS as opt}
 										<button
 											type="button"
+											role="radio"
+											aria-checked={mode === opt.value}
 											onclick={() => (mode = opt.value)}
 											class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {mode ===
 											opt.value
@@ -299,6 +309,9 @@
 										<span class="relative flex items-center" bind:this={draftInfoRef}>
 											<button
 												type="button"
+												aria-label="드래프트 방식 설명"
+												aria-expanded={showDraftInfo}
+												aria-controls="draft-info-popover"
 												onclick={() => (showDraftInfo = !showDraftInfo)}
 												class="flex cursor-pointer items-center hover:text-accent {showDraftInfo
 													? 'text-accent'
@@ -308,6 +321,8 @@
 											</button>
 											{#if showDraftInfo}
 												<div
+													id="draft-info-popover"
+													role="tooltip"
 													class="absolute top-1/2 left-full z-10 ml-2 w-[260px] -translate-y-1/2 border border-accent bg-bg-primary p-3 shadow-lg"
 												>
 													<div class="flex flex-col gap-2">
@@ -337,10 +352,12 @@
 											{/if}
 										</span>
 									</div>
-									<div class="flex gap-2.5">
+									<div class="flex gap-2.5" role="radiogroup" aria-label="드래프트 방식">
 										{#each DRAFT_OPTIONS as opt}
 											<button
 												type="button"
+												role="radio"
+												aria-checked={draftType === opt.value}
 												onclick={() => (draftType = opt.value)}
 												class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {draftType ===
 												opt.value
@@ -408,13 +425,13 @@
 								: 'border-gray-700'}"
 						>
 							<div class="flex items-center justify-between">
-								<span
+								<h2
 									class="font-mono text-sm font-bold tracking-wider {activeStep === 2
 										? 'text-accent'
 										: 'text-gray-50'}"
 								>
 									3단계 선수
-								</span>
+								</h2>
 								<span class="font-mono text-xs text-muted">
 									{players.length}명
 								</span>
@@ -435,11 +452,13 @@
 												type="text"
 												bind:value={player.name}
 												placeholder="선수 이름"
+												aria-label="선수 {i + 1} 이름"
 												class="h-10 flex-1 border border-gray-700 bg-transparent px-3 font-mono text-sm text-gray-50 placeholder:text-subtle focus:border-accent focus:outline-none"
 											/>
 											{#if hasRoles}
 												<select
 													bind:value={player.position}
+													aria-label="선수 {i + 1} 역할"
 													class="h-10 w-[140px] border border-gray-700 bg-bg-primary px-3 font-mono text-sm text-gray-50 focus:border-accent focus:outline-none"
 												>
 													{#each roles as role}
@@ -449,6 +468,7 @@
 											{/if}
 											<select
 												bind:value={player.tier}
+												aria-label="선수 {i + 1} 등급"
 												class="h-10 w-[100px] border border-gray-700 bg-bg-primary px-3 font-mono text-sm text-gray-50 focus:border-accent focus:outline-none"
 											>
 												{#each TIERS as t}
@@ -457,6 +477,7 @@
 											</select>
 											<button
 												type="button"
+												aria-label="선수 {i + 1} 삭제"
 												onclick={() => removePlayer(i)}
 												class="flex h-10 w-8 items-center justify-center text-subtle hover:text-error"
 											>
@@ -482,13 +503,13 @@
 								? 'border-accent'
 								: 'border-gray-700'}"
 						>
-							<span
+							<h2
 								class="font-mono text-sm font-bold tracking-wider {activeStep === 3
 									? 'text-accent'
 									: 'text-gray-50'}"
 							>
 								4단계 감독
-							</span>
+							</h2>
 							<div class="flex flex-col gap-2">
 								<label
 									for="captainsNeeded"

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -1,6 +1,102 @@
 <script lang="ts">
-	import { Sidebar, Icon, Button, ThemePicker } from '$lib/components';
+	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
+	import { Template } from '$lib/domain/template';
+	import type { GameType, TemplateModeType, DraftModeType } from '$lib/domain/template/types';
+
+	// --- State ---
+	let name = $state('');
+	let gameType = $state<GameType>('LEAGUE_OF_LEGENDS');
+	let mode = $state<TemplateModeType>('DRAFT');
+	let totalPoints = $state(1000);
+	let minBid = $state(10);
+	let pickBanTime = $state(30);
+	let draftType = $state<DraftModeType>('SNAKE');
+	let captainsNeeded = $state(2);
+	let creatorAsCaptain = $state(true);
+	let showDraftInfo = $state(false);
+	let draftInfoRef = $state<HTMLElement | null>(null);
+	let activeStep = $state<number | null>(null);
+	let stepRefs = $state<(HTMLElement | null)[]>([null, null, null, null]);
+
+	// --- 선수 관련 ---
+	const TIERS = ['S+', 'S', 'A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D'] as const;
+	type TierType = (typeof TIERS)[number];
+
+	interface PlayerEntry {
+		name: string;
+		position: string;
+		tier: TierType;
+	}
+
+	const ROLES_BY_GAME: Record<GameType, string[]> = {
+		LEAGUE_OF_LEGENDS: ['탑', '정글', '미드', '원딜', '서포터'],
+		VALORANT: ['듀얼리스트', '이니시에이터', '컨트롤러', '센티널'],
+		OVERWATCH_2: ['탱커', '딜러', '서포터'],
+		BATTLEGROUNDS: []
+	};
+
+	let players = $state<PlayerEntry[]>([]);
+	let roles = $derived(ROLES_BY_GAME[gameType]);
+	let hasRoles = $derived(roles.length > 0);
+
+	// --- Derived ---
+	let completion = $derived(
+		Template.getCompletionRate({
+			name,
+			gameType,
+			pickBanTime,
+			mode,
+			totalPoints,
+			minBid,
+			players,
+			captainsNeeded
+		})
+	);
+
+	// --- 옵션 상수 ---
+	const GAME_OPTIONS: { value: GameType; label: string }[] = [
+		{ value: 'LEAGUE_OF_LEGENDS', label: '리그 오브 레전드' },
+		{ value: 'VALORANT', label: '발로란트' },
+		{ value: 'OVERWATCH_2', label: '오버워치2' },
+		{ value: 'BATTLEGROUNDS', label: '배틀그라운드' }
+	];
+	const MODE_OPTIONS: { value: TemplateModeType; label: string }[] = [
+		{ value: 'DRAFT', label: '드래프트' },
+		{ value: 'AUCTION', label: '경매' }
+	];
+	const DRAFT_OPTIONS: { value: DraftModeType; label: string }[] = [
+		{ value: 'SNAKE', label: '스네이크' },
+		{ value: 'SEQUENTIAL', label: '순차' }
+	];
+
+	// --- Functions ---
+	function setGameType(gt: GameType) {
+		gameType = gt;
+		const newRoles = ROLES_BY_GAME[gt];
+		for (const player of players) {
+			player.position = newRoles.length > 0 ? newRoles[0]! : '';
+		}
+	}
+
+	function addPlayer() {
+		players.push({ name: '', position: hasRoles ? roles[0]! : '', tier: 'B' });
+	}
+
+	function removePlayer(index: number) {
+		players.splice(index, 1);
+	}
+
+	function handleGlobalClick(e: MouseEvent) {
+		const target = e.target as Node;
+		if (showDraftInfo && draftInfoRef && !draftInfoRef.contains(target)) {
+			showDraftInfo = false;
+		}
+		const clickedStep = stepRefs.findIndex((ref) => ref?.contains(target));
+		activeStep = clickedStep >= 0 ? clickedStep : null;
+	}
 </script>
+
+<svelte:window onclick={handleGlobalClick} />
 
 <svelte:head>
 	<title>템플릿 생성 | Fantazzk</title>
@@ -43,12 +139,10 @@
 	<div class="flex flex-1 flex-col">
 		<!-- Header -->
 		<header class="flex h-16 items-center justify-between border-b border-gray-700 px-14">
-			<div class="flex items-center gap-4">
-				<span class="font-heading text-2xl font-bold tracking-wider text-gray-50">
-					NEW TEMPLATE
-				</span>
-				<span class="font-mono text-sm text-muted">/</span>
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent"> CREATE </span>
+			<div class="flex items-center gap-2">
+				<span class="font-heading text-2xl font-bold tracking-wider text-gray-50"> 새 템플릿 </span>
+				<span class="font-mono text-sm font-semibold text-accent"> 기본 정보 </span>
+				<span class="font-mono text-sm text-muted"> 설정 </span>
 			</div>
 			<a href="/" aria-label="닫기">
 				<Icon name="close" color="currentColor" />
@@ -58,48 +152,53 @@
 		<!-- Content Body -->
 		<div class="flex flex-1 overflow-hidden">
 			<!-- Steps Panel -->
-			<aside class="flex w-[220px] flex-col gap-7 border-r border-gray-700 px-7 py-12">
-				<span class="font-mono text-[11px] font-semibold tracking-[1.6px] text-muted">
-					STEPS / 04
-				</span>
-
-				<!-- 편집 패턴 힌트 -->
-				<div class="flex flex-col gap-1.5 rounded-sm border border-gray-800 bg-bg-surface p-2.5">
-					<span class="font-mono text-[10px] font-bold tracking-wider text-muted">
-						편집 패턴 안내
-					</span>
-					<p class="font-mono text-[11px] leading-snug text-gray-50">
-						한 페이지 편집: 전체 항목을 한 번에 수정<br />
-						단계별 편집: STEP별로 순차 수정 (현재)
-					</p>
+			<aside class="flex w-[240px] flex-col gap-7 border-r border-gray-700 px-7 py-12">
+				<!-- 진행률 -->
+				<div class="flex flex-col gap-2">
+					<div class="flex items-center justify-between">
+						<span class="font-mono text-xs font-semibold text-muted">진행률</span>
+						<span class="font-mono text-xs font-semibold text-accent">{completion.percent}%</span>
+					</div>
+					<div class="h-1 w-full rounded-full bg-gray-700">
+						<div class="h-full rounded-full bg-accent" style="width: {completion.percent}%"></div>
+					</div>
 				</div>
 
 				<!-- Steps List -->
 				<div class="flex flex-col gap-2.5">
-					<!-- Step 1: 완료 -->
-					<div class="flex flex-col gap-1 border-l-2 border-gray-700 bg-bg-primary p-3">
-						<span class="font-mono text-[11px] font-bold tracking-wider text-muted"> STEP 1 </span>
-						<span class="font-mono text-xs text-muted">기본 정보 입력 단계</span>
-						<span class="font-mono text-[11px] font-semibold text-subtle"> 상태: 준비됨 </span>
-					</div>
-					<!-- Step 2: 현재 (Active) -->
-					<div class="flex flex-col gap-1 border-l-[3px] border-accent bg-bg-surface p-3">
-						<span class="font-mono text-[11px] font-bold tracking-wider text-accent"> STEP 2 </span>
-						<span class="font-mono text-xs font-semibold text-gray-50">
-							규칙 설정 및 확인 단계
-						</span>
-						<span class="font-mono text-[11px] font-bold text-accent"> 상태: 진행 중 </span>
-					</div>
-					<!-- Step 3: 미완료 -->
-					<div class="flex items-center gap-3.5 p-2.5 pl-3 opacity-70">
-						<span class="font-mono text-[11px] font-bold tracking-wider text-muted"> STEP 3 </span>
-						<span class="font-mono text-xs text-muted">선수 설정</span>
-					</div>
-					<!-- Step 4: 미완료 -->
-					<div class="flex items-center gap-3.5 p-2.5 pl-3 opacity-70">
-						<span class="font-mono text-[11px] font-bold tracking-wider text-muted"> STEP 4 </span>
-						<span class="font-mono text-xs text-muted">캡틴 설정</span>
-					</div>
+					{#each [{ label: '기본 정보' }, { label: '규칙' }, { label: '선수' }, { label: '감독' }] as step, i}
+						<button
+							type="button"
+							onclick={() => stepRefs[i]?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
+							class="flex flex-col gap-1 border-l-[3px] p-3 text-left {activeStep === i
+								? 'border-accent bg-bg-surface'
+								: 'border-gray-700'}"
+						>
+							<div class="flex items-center justify-between">
+								<span
+									class="font-mono text-xs font-bold tracking-wider {activeStep === i
+										? 'text-accent'
+										: 'text-muted'}"
+								>
+									STEP {i + 1}
+								</span>
+								<span
+									class="font-mono text-xs {completion.steps[i] === 100
+										? 'text-accent'
+										: 'text-subtle'}"
+								>
+									{completion.steps[i]}%
+								</span>
+							</div>
+							<span
+								class="font-mono text-sm {activeStep === i
+									? 'font-semibold text-gray-50'
+									: 'text-muted'}"
+							>
+								{step.label}
+							</span>
+						</button>
+					{/each}
 				</div>
 			</aside>
 
@@ -107,349 +206,382 @@
 			<main class="flex flex-1 flex-col overflow-y-auto">
 				<div class="flex flex-1 flex-col gap-8 px-14 py-12">
 					<!-- Form Title -->
-					<div class="flex flex-col gap-2">
-						<h1 class="font-heading text-4xl font-bold tracking-tight text-gray-50">
-							Template Setup
-						</h1>
-						<p class="font-mono text-sm leading-relaxed text-muted">
-							기본은 한 페이지 위저드로 진행하고, 복잡도 높을 때 단계별 페이지로 분리합니다.
-						</p>
-					</div>
-
-					<!-- 편집 방식 가이드 -->
-					<div class="flex flex-col gap-2.5 border border-gray-700 p-4">
-						<span class="font-mono text-xs font-bold tracking-wider text-gray-50"> 편집 방식 </span>
-						<div class="flex gap-2.5">
-							<span
-								class="border border-accent bg-accent px-3 py-1.5 font-mono text-[11px] font-semibold text-bg-primary"
-							>
-								한 페이지 편집
-							</span>
-							<span
-								class="border border-gray-700 px-3 py-1.5 font-mono text-[11px] font-semibold text-muted"
-							>
-								단계별 편집
-							</span>
-						</div>
-						<p class="font-mono text-xs leading-relaxed text-muted">
-							필드 수가 적고 미리보기 의존도가 높으면 한 페이지가 일반적입니다. 검증/권한/협업이
-							단계별로 다르면 분리하세요.
-						</p>
-					</div>
-
-					<!-- STEP 상태 해석 -->
-					<div class="flex flex-col gap-2.5 border border-gray-700 p-3">
-						<span class="font-mono text-xs font-bold tracking-wider text-gray-50">
-							STEP 상태 해석
-						</span>
-						<div class="flex gap-2.5">
-							<span class="flex items-center gap-2">
-								<span class="h-3 w-3 border-l-2 border-gray-700"></span>
-								<span class="font-mono text-[11px] text-muted">준비됨</span>
-							</span>
-							<span class="flex items-center gap-2">
-								<span class="h-3 w-3 border-l-[3px] border-accent bg-accent/20"></span>
-								<span class="font-mono text-[11px] text-accent">진행 중</span>
-							</span>
-							<span class="flex items-center gap-2">
-								<span class="h-3 w-3 opacity-50">
-									<span class="block h-full w-0.5 bg-gray-700"></span>
-								</span>
-								<span class="font-mono text-[11px] text-subtle">미완료</span>
-							</span>
-						</div>
-						<p class="font-mono text-xs leading-relaxed text-muted">
-							현재 화면에서 STEP 2의 금색 채움은 포커스가 아니라 '현재 진행 단계(Active)'를
-							의미합니다.
-						</p>
-					</div>
+					<h1 class="font-heading text-4xl font-bold tracking-tight text-gray-50">템플릿 설정</h1>
 
 					<!-- Step Sections -->
 					<div class="flex flex-col gap-5">
-						<!-- STEP 1: BASIC INFORMATION -->
-						<section class="flex flex-col gap-3 border border-gray-700 p-4">
-							<span class="font-mono text-xs font-bold tracking-wider text-gray-50">
-								STEP 1 BASIC INFORMATION
+						<!-- STEP 1: 기본 정보 -->
+						<section
+							bind:this={stepRefs[0]}
+							class="flex flex-col gap-3 border p-5 {activeStep === 0
+								? 'border-accent'
+								: 'border-gray-700'}"
+						>
+							<span
+								class="font-mono text-sm font-bold tracking-wider {activeStep === 0
+									? 'text-accent'
+									: 'text-gray-50'}"
+							>
+								1단계 기본 정보
 							</span>
 							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									TOURNAMENT NAME
-								</span>
-								<div class="flex h-11 items-center border border-gray-700 px-4">
-									<span class="font-mono text-sm text-gray-50"> 2026 자낳대 롤 시즌1 </span>
-								</div>
+								<label for="name" class="font-mono text-xs font-semibold tracking-[2px] text-muted">
+									대회 이름
+								</label>
+								<input
+									id="name"
+									type="text"
+									bind:value={name}
+									placeholder="예: 2026 자낳대 롤 시즌1"
+									class="h-12 border border-gray-700 bg-transparent px-4 font-mono text-base text-gray-50 placeholder:text-subtle focus:border-accent focus:outline-none"
+								/>
 							</div>
 							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									GAME TYPE
+								<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
+									게임 종목
 								</span>
 								<div class="flex gap-2.5">
-									<span
-										class="border border-accent bg-accent px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-bg-primary"
-									>
-										LEAGUE OF LEGENDS
-									</span>
-									<span
-										class="border border-gray-700 px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-muted"
-									>
-										VALORANT
-									</span>
+									{#each GAME_OPTIONS as opt}
+										<button
+											type="button"
+											onclick={() => setGameType(opt.value)}
+											class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {gameType ===
+											opt.value
+												? 'border-accent bg-accent text-bg-primary'
+												: 'border-gray-700 text-muted'}"
+										>
+											{opt.label}
+										</button>
+									{/each}
 								</div>
 							</div>
 						</section>
 
-						<!-- STEP 2: RULES (Active) -->
-						<section class="flex flex-col gap-3 border border-accent p-4">
-							<span class="font-mono text-xs font-bold tracking-wider text-accent">
-								STEP 2 RULES
+						<!-- STEP 2: 규칙 -->
+						<section
+							bind:this={stepRefs[1]}
+							class="flex flex-col gap-3 border p-5 {activeStep === 1
+								? 'border-accent'
+								: 'border-gray-700'}"
+						>
+							<span
+								class="font-mono text-sm font-bold tracking-wider {activeStep === 1
+									? 'text-accent'
+									: 'text-gray-50'}"
+							>
+								2단계 규칙
 							</span>
 							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									MATCH FORMAT
+								<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
+									진행 방식
 								</span>
 								<div class="flex gap-2.5">
-									<span
-										class="border border-accent bg-accent px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-bg-primary"
-									>
-										Auction
-									</span>
-									<span
-										class="border border-gray-700 px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-muted"
-									>
-										Draft
-									</span>
+									{#each MODE_OPTIONS as opt}
+										<button
+											type="button"
+											onclick={() => (mode = opt.value)}
+											class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {mode ===
+											opt.value
+												? 'border-accent bg-accent text-bg-primary'
+												: 'border-gray-700 text-muted'}"
+										>
+											{opt.label}
+										</button>
+									{/each}
 								</div>
 							</div>
-							<div class="flex gap-4">
-								<div class="flex flex-1 flex-col gap-2">
-									<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-										INITIAL POINTS
-									</span>
-									<div class="flex h-11 items-center border border-gray-700 px-4">
-										<span class="font-mono text-sm text-gray-50">1,000</span>
+							{#if mode === 'DRAFT'}
+								<div class="flex flex-col gap-2">
+									<div class="flex items-center gap-1.5">
+										<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
+											드래프트 방식
+										</span>
+										<span class="relative flex items-center" bind:this={draftInfoRef}>
+											<button
+												type="button"
+												onclick={() => (showDraftInfo = !showDraftInfo)}
+												class="flex cursor-pointer items-center hover:text-accent {showDraftInfo
+													? 'text-accent'
+													: 'text-subtle'}"
+											>
+												<Icon name="info" size={14} />
+											</button>
+											{#if showDraftInfo}
+												<div
+													class="absolute top-1/2 left-full z-10 ml-2 w-[260px] -translate-y-1/2 border border-accent bg-bg-primary p-3 shadow-lg"
+												>
+													<div class="flex flex-col gap-2">
+														<div class="flex flex-col gap-1">
+															<span class="font-mono text-xs font-semibold text-accent"
+																>스네이크</span
+															>
+															<div class="font-mono text-xs leading-relaxed text-gray-50">
+																1→2→3→4→5<br />
+																5→4→3→2→1<br />
+																1→2→3→4→5<br />
+																<span class="text-muted">↻ 매 라운드 순서 반전</span>
+															</div>
+														</div>
+														<div class="h-px bg-gray-700"></div>
+														<div class="flex flex-col gap-1">
+															<span class="font-mono text-xs font-semibold text-accent">순차</span>
+															<div class="font-mono text-xs leading-relaxed text-gray-50">
+																1→2→3→4→5<br />
+																1→2→3→4→5<br />
+																1→2→3→4→5<br />
+																<span class="text-muted">↻ 매 라운드 동일 순서</span>
+															</div>
+														</div>
+													</div>
+												</div>
+											{/if}
+										</span>
+									</div>
+									<div class="flex gap-2.5">
+										{#each DRAFT_OPTIONS as opt}
+											<button
+												type="button"
+												onclick={() => (draftType = opt.value)}
+												class="border px-4 py-2.5 font-mono text-xs font-semibold tracking-wider {draftType ===
+												opt.value
+													? 'border-accent bg-accent text-bg-primary'
+													: 'border-gray-700 text-muted'}"
+											>
+												{opt.label}
+											</button>
+										{/each}
 									</div>
 								</div>
-								<div class="flex flex-1 flex-col gap-2">
-									<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-										MIN BID
-									</span>
-									<div class="flex h-11 items-center border border-gray-700 px-4">
-										<span class="font-mono text-sm text-gray-50">10</span>
+							{:else}
+								<div class="flex gap-4">
+									<div class="flex flex-1 flex-col gap-2">
+										<label
+											for="totalPoints"
+											class="font-mono text-xs font-semibold tracking-[2px] text-muted"
+										>
+											초기 포인트
+										</label>
+										<input
+											id="totalPoints"
+											type="number"
+											bind:value={totalPoints}
+											class="h-12 border border-gray-700 bg-transparent px-4 font-mono text-base text-gray-50 focus:border-accent focus:outline-none"
+										/>
+									</div>
+									<div class="flex flex-1 flex-col gap-2">
+										<label
+											for="minBid"
+											class="font-mono text-xs font-semibold tracking-[2px] text-muted"
+										>
+											최소 입찰 단위
+										</label>
+										<input
+											id="minBid"
+											type="number"
+											bind:value={minBid}
+											class="h-12 border border-gray-700 bg-transparent px-4 font-mono text-base text-gray-50 focus:border-accent focus:outline-none"
+										/>
 									</div>
 								</div>
-							</div>
+							{/if}
 							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[1.4px] text-muted">
-									PICK/BAN TIME (sec)
-								</span>
-								<div class="flex h-11 items-center border border-gray-700 px-4">
-									<span class="font-mono text-sm text-gray-50">30</span>
-								</div>
-							</div>
-							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									RESTRICTIONS / NOTES
-								</span>
-								<div class="flex h-[70px] items-start border border-gray-700 px-4 py-2.5">
-									<span class="font-mono text-sm text-muted"> 국/외인 제한 없이 교대 </span>
-								</div>
+								<label
+									for="pickBanTime"
+									class="font-mono text-xs font-semibold tracking-[1.4px] text-muted"
+								>
+									픽/밴 시간 (초)
+								</label>
+								<input
+									id="pickBanTime"
+									type="number"
+									bind:value={pickBanTime}
+									class="h-12 border border-gray-700 bg-transparent px-4 font-mono text-base text-gray-50 focus:border-accent focus:outline-none"
+								/>
 							</div>
 						</section>
 
-						<!-- STEP 3: PLAYERS -->
-						<section class="flex flex-col gap-3 border border-gray-700 p-4">
-							<span class="font-mono text-xs font-bold tracking-wider text-gray-50">
-								STEP 3 PLAYERS
-							</span>
-							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									TOTAL PLAYERS
+						<!-- STEP 3: 선수 -->
+						<section
+							bind:this={stepRefs[2]}
+							class="flex flex-col gap-3 border p-5 {activeStep === 2
+								? 'border-accent'
+								: 'border-gray-700'}"
+						>
+							<div class="flex items-center justify-between">
+								<span
+									class="font-mono text-sm font-bold tracking-wider {activeStep === 2
+										? 'text-accent'
+										: 'text-gray-50'}"
+								>
+									3단계 선수
 								</span>
-								<div class="flex h-11 items-center border border-gray-700 px-4">
-									<span class="font-mono text-sm text-gray-50"></span>
-								</div>
-							</div>
-							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									TIER BALANCING
+								<span class="font-mono text-xs text-muted">
+									{players.length}명
 								</span>
-								<div class="flex gap-2.5">
-									<span
-										class="border border-accent bg-accent px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-bg-primary"
-									>
-										AUTO BALANCE
-									</span>
-									<span
-										class="border border-gray-700 px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-muted"
-									>
-										MANUAL
-									</span>
-								</div>
 							</div>
+							{#if players.length > 0}
+								<div class="flex flex-col gap-2">
+									<div class="flex gap-2 font-mono text-xs font-semibold tracking-[2px] text-muted">
+										<span class="flex-1">이름</span>
+										{#if hasRoles}
+											<span class="w-[140px]">역할</span>
+										{/if}
+										<span class="w-[100px]">등급</span>
+										<span class="w-8"></span>
+									</div>
+									{#each players as player, i}
+										<div class="flex items-center gap-2">
+											<input
+												type="text"
+												bind:value={player.name}
+												placeholder="선수 이름"
+												class="h-10 flex-1 border border-gray-700 bg-transparent px-3 font-mono text-sm text-gray-50 placeholder:text-subtle focus:border-accent focus:outline-none"
+											/>
+											{#if hasRoles}
+												<select
+													bind:value={player.position}
+													class="h-10 w-[140px] border border-gray-700 bg-bg-primary px-3 font-mono text-sm text-gray-50 focus:border-accent focus:outline-none"
+												>
+													{#each roles as role}
+														<option value={role}>{role}</option>
+													{/each}
+												</select>
+											{/if}
+											<select
+												bind:value={player.tier}
+												class="h-10 w-[100px] border border-gray-700 bg-bg-primary px-3 font-mono text-sm text-gray-50 focus:border-accent focus:outline-none"
+											>
+												{#each TIERS as t}
+													<option value={t}>{t}</option>
+												{/each}
+											</select>
+											<button
+												type="button"
+												onclick={() => removePlayer(i)}
+												class="flex h-10 w-8 items-center justify-center text-subtle hover:text-error"
+											>
+												<Icon name="close" size={14} />
+											</button>
+										</div>
+									{/each}
+								</div>
+							{/if}
+							<button
+								type="button"
+								onclick={addPlayer}
+								class="flex h-10 items-center justify-center gap-1.5 border border-dashed border-gray-700 font-mono text-xs text-muted hover:border-accent hover:text-accent"
+							>
+								+ 선수 추가
+							</button>
 						</section>
 
-						<!-- STEP 4: CAPTAINS -->
-						<section class="flex flex-col gap-3 border border-gray-700 p-4">
-							<span class="font-mono text-xs font-bold tracking-wider text-gray-50">
-								STEP 4 CAPTAINS
+						<!-- STEP 4: 감독 -->
+						<section
+							bind:this={stepRefs[3]}
+							class="flex flex-col gap-3 border p-5 {activeStep === 3
+								? 'border-accent'
+								: 'border-gray-700'}"
+						>
+							<span
+								class="font-mono text-sm font-bold tracking-wider {activeStep === 3
+									? 'text-accent'
+									: 'text-gray-50'}"
+							>
+								4단계 감독
 							</span>
 							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									CAPTAIN SELECT MODE
-								</span>
-								<div class="flex gap-2.5">
-									<span
-										class="border border-accent bg-accent px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-bg-primary"
-									>
-										VOTE
-									</span>
-									<span
-										class="border border-gray-700 px-4 py-2 font-mono text-[11px] font-semibold tracking-wider text-muted"
-									>
-										HOST PICK
-									</span>
-								</div>
+								<label
+									for="captainsNeeded"
+									class="font-mono text-xs font-semibold tracking-[2px] text-muted"
+								>
+									감독 수
+								</label>
+								<input
+									id="captainsNeeded"
+									type="number"
+									bind:value={captainsNeeded}
+									min="1"
+									class="h-12 border border-gray-700 bg-transparent px-4 font-mono text-base text-gray-50 focus:border-accent focus:outline-none"
+								/>
 							</div>
-							<div class="flex flex-col gap-2">
-								<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-									CAPTAINS NEEDED
-								</span>
-								<div class="flex h-11 items-center border border-gray-700 px-4">
-									<span class="font-mono text-sm text-gray-50"></span>
-								</div>
+							<div class="flex items-center justify-end gap-3">
+								<span class="font-mono text-sm text-gray-50">본인도 감독으로 참여</span>
+								<Toggle bind:checked={creatorAsCaptain} label="본인도 감독으로 참여" />
 							</div>
 						</section>
 					</div>
 				</div>
 
 				<!-- Bottom Bar -->
-				<div class="flex items-center justify-between border-t border-gray-700 px-14 py-4">
-					<Button variant="SECONDARY" size="MD">SAVE DRAFT</Button>
-					<Button variant="PRIMARY" size="MD">SAVE ALL STEPS ✓</Button>
+				<div class="flex items-center justify-end gap-3 border-t border-gray-700 px-14 py-4">
+					<Button variant="SECONDARY" size="MD">혼자 하기</Button>
+					<Button variant="PRIMARY" size="MD">방 만들기</Button>
 				</div>
 			</main>
 
 			<!-- Preview Panel -->
 			<aside class="flex w-[360px] flex-col gap-4 overflow-y-auto bg-bg-elevated px-7 py-10">
-				<!-- Live Preview Label -->
-				<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-					LIVE PREVIEW
-				</span>
-
-				<!-- Preview Card -->
-				<div class="flex flex-col gap-3.5 border border-gray-700 p-4">
-					<span class="font-heading text-xl font-bold text-gray-50"> 2026 자낳대 롤 시즌1 </span>
-					<span
-						class="w-fit bg-accent px-2.5 py-1 font-mono text-[10px] font-semibold text-bg-primary"
-					>
-						AUCTION OF LEGENDS
-					</span>
-					<div class="h-px w-full bg-gray-700"></div>
-
-					<!-- Basic Info Preview -->
-					<div class="flex flex-col gap-2.5 rounded-sm border border-gray-800 bg-bg-surface p-3">
-						<span class="font-mono text-[10px] font-semibold tracking-wider text-muted">
-							STEP 1 BASIC INFORMATION
-						</span>
-						<div class="flex items-center gap-2">
-							<span class="font-mono text-[10px] font-semibold tracking-wider text-accent">
-								PICK YOUR TYPE
-							</span>
-							<span class="font-mono text-[10px] tracking-wider text-muted">
-								LEAGUE OF LEGENDS
-							</span>
-						</div>
-					</div>
-
-					<!-- Stats Row -->
-					<div class="flex justify-between">
-						<div class="flex flex-col items-center">
-							<span class="font-heading text-lg font-bold text-gray-50">8</span>
-							<span class="font-mono text-[9px] tracking-wider text-muted"> TEAMS </span>
-						</div>
-						<div class="flex flex-col items-center">
-							<span class="font-heading text-lg font-bold text-gray-50"> 1,000 </span>
-							<span class="font-mono text-[9px] tracking-wider text-muted"> POINTS </span>
-						</div>
-					</div>
-
-					<!-- Rules Preview -->
-					<div class="flex flex-col gap-2.5 rounded-sm border border-gray-800 bg-bg-surface p-3">
-						<span class="font-mono text-[10px] font-semibold tracking-wider text-muted">
-							STEP 2 RULES
-						</span>
-						<div class="flex flex-col gap-1">
-							<span class="font-mono text-[10px] text-muted"> Auction · 30s Timer </span>
-							<span class="font-mono text-[10px] text-muted"> 국/외인 제한 없이 교대 </span>
-						</div>
-					</div>
-
-					<!-- Visibility -->
-					<div class="flex items-center justify-between">
-						<span class="font-mono text-[11px] font-semibold text-gray-50"> PUBLIC TEMPLATE </span>
-						<div class="flex h-6 w-10 items-center rounded-full bg-accent px-0.5">
-							<div class="ml-auto h-5 w-5 rounded-full bg-bg-primary"></div>
-						</div>
-					</div>
-				</div>
-
-				<!-- Completion -->
-				<div class="flex flex-col gap-2">
-					<span class="font-mono text-[11px] font-semibold tracking-[2px] text-muted">
-						COMPLETION
-					</span>
-					<div class="h-1 w-full bg-gray-700">
-						<div class="h-full w-1/4 bg-accent"></div>
-					</div>
-					<span class="font-mono text-xs text-subtle">1 of 4 steps completed</span>
-
-					<!-- Status Legend -->
-					<div class="flex flex-col gap-1.5 rounded-sm border border-gray-800 bg-bg-surface p-2.5">
-						<div class="flex items-center gap-2">
-							<span class="font-mono text-[10px] font-semibold text-accent"> ACTIVE </span>
-							<span class="font-mono text-[10px] text-muted"> Step 2 — Rules </span>
-						</div>
-						<div class="flex items-center gap-2">
-							<span class="font-mono text-[10px] font-semibold text-muted"> DONE </span>
-							<span class="font-mono text-[10px] text-muted"> Step 1 — Basic Info </span>
-						</div>
-					</div>
-				</div>
-
 				<!-- Tips -->
 				<div class="flex flex-col gap-2 rounded-sm border border-gray-800 p-3">
-					<div class="flex items-center gap-2">
-						<span class="font-mono text-[11px] font-semibold tracking-wider text-accent">
-							TIPS
-						</span>
-					</div>
-					<p class="font-mono text-xs leading-relaxed text-muted">
-						Use the exact tournament name from the official announcement for easy discoverability.
+					<span class="font-mono text-sm font-semibold tracking-wider text-accent"> 팁 </span>
+					<p class="font-mono text-sm leading-relaxed text-muted">
+						공식 발표에 사용된 정확한 대회 이름을 입력하면 다른 유저가 쉽게 찾을 수 있습니다.
 					</p>
 				</div>
 
-				<!-- Decision Guide -->
-				<div class="flex flex-col gap-2.5 rounded-sm border border-gray-800 bg-bg-surface p-3">
-					<span class="font-mono text-[11px] font-semibold tracking-wider text-accent">
-						DECISION GUIDE
+				<!-- Summary -->
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-muted"> 요약 </span>
+
+				<div class="flex flex-col gap-3.5 border border-gray-700 p-4">
+					<span class="font-heading text-xl font-bold text-gray-50">
+						{name || '대회 이름 미입력'}
 					</span>
-					<span class="font-mono text-xs font-semibold text-gray-50">
-						한 페이지 편집이 적합한 경우
+					<span class="w-fit bg-accent px-2.5 py-1 font-mono text-xs font-semibold text-bg-primary">
+						{mode === 'AUCTION' ? '경매' : '드래프트'}
 					</span>
-					<p class="font-mono text-xs leading-relaxed text-muted">
-						필드가 5~8개 내외로 적고<br />
-						초기 세팅을 빠르게 끝내야 할 때<br />
-						입력 흐름을 한 번에 훑어야 할 때
-					</p>
 					<div class="h-px w-full bg-gray-700"></div>
-					<span class="font-mono text-xs font-semibold text-gray-50">
-						단계별 페이지가 적합한 경우
-					</span>
-					<p class="font-mono text-xs leading-relaxed text-muted">
-						설정 항목이 많아 검토 포인트가 분리될 때<br />
-						단계별 검증/안내 문구가 필요한 복잡한 플로우일 때<br />
-						중간 저장과 진행률 안내가 중요한 경우
-					</p>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="font-mono text-xs text-muted">게임 종목</span>
+							<span class="font-mono text-xs text-gray-50">{gameType.replace(/_/g, ' ')}</span>
+						</div>
+						<div class="flex items-center justify-between">
+							<span class="font-mono text-xs text-muted">픽/밴 시간</span>
+							<span class="font-mono text-xs text-gray-50">{pickBanTime}초</span>
+						</div>
+						{#if mode === 'AUCTION'}
+							<div class="flex items-center justify-between">
+								<span class="font-mono text-xs text-muted">초기 포인트</span>
+								<span class="font-mono text-xs text-gray-50">{totalPoints.toLocaleString()}</span>
+							</div>
+							<div class="flex items-center justify-between">
+								<span class="font-mono text-xs text-muted">최소 입찰 단위</span>
+								<span class="font-mono text-xs text-gray-50">{minBid}</span>
+							</div>
+						{:else}
+							<div class="flex items-center justify-between">
+								<span class="font-mono text-xs text-muted">드래프트 방식</span>
+								<span class="font-mono text-xs text-gray-50"
+									>{draftType === 'SNAKE' ? '스네이크' : '순차'}</span
+								>
+							</div>
+						{/if}
+						<div class="flex items-center justify-between">
+							<span class="font-mono text-xs text-muted">선수</span>
+							<span class="font-mono text-xs text-gray-50">{players.length}명</span>
+						</div>
+						<div class="flex items-center justify-between">
+							<span class="font-mono text-xs text-muted">감독 수</span>
+							<span class="font-mono text-xs text-gray-50">{captainsNeeded}명</span>
+						</div>
+						<div class="flex items-center justify-between">
+							<span class="font-mono text-xs text-muted">본인 참여</span>
+							<span class="font-mono text-xs text-gray-50"
+								>{creatorAsCaptain ? '예' : '아니오'}</span
+							>
+						</div>
+					</div>
 				</div>
 			</aside>
 		</div>


### PR DESCRIPTION
## Summary
- `/templates/create` 하드코딩 목업을 실제 입력 폼으로 교체 (Svelte 5 rune 기반)
- 게임종목별 역할 select, 선수 등급(S+~D), 감독 수/본인 참여 설정
- 진행방식(드래프트/경매)에 따른 조건부 필드 노출
- Template 도메인 모델 리팩터링 — `tier`, `draftMode`, `creatorAsCaptain` 추가, 미사용 필드 제거
- `Template.getCompletionRate` 단계별 진행률 계산 + 테스트 11건 추가
- 전역 색상 transition, `Toggle` 공용 컴포넌트, `info` 아이콘 추가
- 드래프트 방식 info 툴팁 (클릭 토글, 외부 클릭 닫기)
- 섹션 클릭 기반 활성화 상태 + Step indicator 연동
- 우측 패널 실시간 요약 카드 (폼 데이터 바인딩)
- UI 전체 한글화 + 폰트 크기 상향

Closes #41