### PR TITLE
설정(api): OpenAPI spec 동기화 — 타입/핸들러/팩토리 업데이트

### DIFF
--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -50,6 +50,34 @@ export interface CreateTemplateRequest {
 
 export type RoomStatus = 'WAITING' | 'IN_PROGRESS' | 'FINISHED';
 
+export interface RoomMemberResponse {
+	teamLeaderId: string;
+	playerName: string;
+	assignOrder: number;
+}
+
+export interface RoomPlayerResponse {
+	name: string;
+	displayOrder: number;
+	status: string;
+}
+
+export interface RoomProgressResponse {
+	currentTurnIndex: number;
+	currentRound: number;
+	currentLeaderId: string;
+	currentRoundLeaderIds: string[];
+}
+
+export interface JoinableRoomResponse {
+	code: string;
+	mode: string;
+	teamCount: number;
+	joinedLeaderCount: number;
+	remainingSlotCount: number;
+	startReadiness: string;
+}
+
 export interface RoomResponse {
 	code: string;
 	status: RoomStatus;
@@ -57,6 +85,12 @@ export interface RoomResponse {
 	teamCount?: number;
 	startReadiness?: string;
 	teamLeaders: TeamLeaderResponse[];
+	teamSize?: number;
+	budget?: number;
+	draftOrderStrategy?: string;
+	players?: RoomPlayerResponse[];
+	members?: RoomMemberResponse[];
+	progress?: RoomProgressResponse;
 }
 
 export interface TeamLeaderResponse {

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -3,7 +3,11 @@ import type {
 	TemplateResponse,
 	RoomResponse,
 	RoomSessionResponse,
-	TeamLeaderResponse
+	TeamLeaderResponse,
+	RoomMemberResponse,
+	RoomPlayerResponse,
+	RoomProgressResponse,
+	JoinableRoomResponse
 } from '$lib/types/api';
 
 // ─── 응답 래퍼 ───
@@ -103,13 +107,99 @@ function createTeamLeaders(count: number, budget: number): TeamLeaderResponse[] 
 	}));
 }
 
+export function createRoomMemberResponse(
+	overrides?: Partial<RoomMemberResponse>
+): RoomMemberResponse {
+	return {
+		teamLeaderId: 'tl-1',
+		playerName: 'KIIN',
+		assignOrder: 0,
+		...overrides
+	};
+}
+
+export function createRoomPlayerResponse(
+	overrides?: Partial<RoomPlayerResponse>
+): RoomPlayerResponse {
+	return {
+		name: 'KIIN',
+		displayOrder: 0,
+		status: 'AVAILABLE',
+		...overrides
+	};
+}
+
+export function createRoomProgressResponse(
+	overrides?: Partial<RoomProgressResponse>
+): RoomProgressResponse {
+	return {
+		currentTurnIndex: 0,
+		currentRound: 1,
+		currentLeaderId: 'tl-1',
+		currentRoundLeaderIds: ['tl-1', 'tl-2'],
+		...overrides
+	};
+}
+
+export function createJoinableRoomResponse(
+	overrides?: Partial<JoinableRoomResponse>
+): JoinableRoomResponse {
+	return {
+		code: 'ABC774',
+		mode: 'AUCTION',
+		teamCount: 8,
+		joinedLeaderCount: 3,
+		remainingSlotCount: 5,
+		startReadiness: 'NOT_READY',
+		...overrides
+	};
+}
+
+export function createJoinableRoomListResponse(): JoinableRoomResponse[] {
+	return [
+		createJoinableRoomResponse({
+			code: 'ABC774',
+			mode: 'AUCTION',
+			teamCount: 8,
+			joinedLeaderCount: 3,
+			remainingSlotCount: 5,
+			startReadiness: 'NOT_READY'
+		}),
+		createJoinableRoomResponse({
+			code: 'XYZ123',
+			mode: 'DRAFT',
+			teamCount: 4,
+			joinedLeaderCount: 2,
+			remainingSlotCount: 2,
+			startReadiness: 'NOT_READY'
+		}),
+		createJoinableRoomResponse({
+			code: 'QRS456',
+			mode: 'AUCTION',
+			teamCount: 6,
+			joinedLeaderCount: 5,
+			remainingSlotCount: 1,
+			startReadiness: 'READY'
+		})
+	];
+}
+
 export function createRoomResponse(overrides?: Partial<RoomResponse>): RoomResponse {
 	return {
 		code: 'ABC774',
 		status: 'WAITING',
 		mode: 'AUCTION',
 		teamCount: 8,
+		teamSize: 5,
+		budget: 1000,
+		draftOrderStrategy: 'SNAKE',
 		teamLeaders: createTeamLeaders(2, 1000),
+		players: [
+			createRoomPlayerResponse({ name: 'KIIN', displayOrder: 0 }),
+			createRoomPlayerResponse({ name: 'ONER', displayOrder: 1 }),
+			createRoomPlayerResponse({ name: 'CHOVY', displayOrder: 2 })
+		],
+		members: [],
 		...overrides
 	};
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,7 +5,8 @@ import {
 	createTemplateDetailResponse,
 	createTemplateResponse,
 	createRoomResponse,
-	createRoomSessionResponse
+	createRoomSessionResponse,
+	createJoinableRoomListResponse
 } from './factories';
 
 const BASE_URL = import.meta.env['PUBLIC_API_URL'] ?? '';
@@ -30,6 +31,10 @@ export const handlers = [
 	}),
 
 	// ─── Room API ───
+
+	http.get(`${BASE_URL}/api/v1/rooms`, () => {
+		return HttpResponse.json(success(createJoinableRoomListResponse()));
+	}),
 
 	http.post(`${BASE_URL}/api/v1/rooms`, () => {
 		return HttpResponse.json(success(createRoomSessionResponse()), { status: 201 });


### PR DESCRIPTION
## sync-api-spec

### 머지된 OpenAPI PR
- #46 — chore(api): sync OpenAPI spec

### 타입 변경 (src/lib/types/api.ts)
- 추가: RoomMemberResponse, RoomPlayerResponse, RoomProgressResponse, JoinableRoomResponse
- 수정: RoomResponse (teamSize, budget, draftOrderStrategy, players, members, progress 필드 추가)

### 핸들러 변경 (src/mocks/handlers.ts)
- 추가: GET /api/v1/rooms

### 팩토리 변경 (src/mocks/factories.ts)
- 추가: createRoomMemberResponse(), createRoomPlayerResponse(), createRoomProgressResponse(), createJoinableRoomResponse(), createJoinableRoomListResponse()
- 수정: createRoomResponse() (새 필드 기본값 추가)