### PR TITLE
기능(draft): 드래프트 솔로 플레이 플로우 구현 (#4)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,12 @@ export default defineConfig(
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			'no-undef': 'off'
+			'no-undef': 'off',
+			// Allow variables prefixed with _ to be unused (common convention for intentionally unused bindings)
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{ varsIgnorePattern: '^_', argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }
+			]
 		}
 	},
 	{

--- a/src/lib/domain/rule-engine/__tests__/draft-driver.test.ts
+++ b/src/lib/domain/rule-engine/__tests__/draft-driver.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'bun:test';
+import { Draft } from '$lib/domain/rule-engine/draft.ts';
+import type { DraftConfig } from '$lib/domain/rule-engine/draft-types.ts';
+import { processPick, processAutoPick } from '../draft-driver.ts';
+
+function createConfig(): DraftConfig {
+	return {
+		teamCount: 2,
+		draftType: 'SEQUENTIAL',
+		rounds: 2,
+		playerPool: [
+			{ name: '선수A', position: 'TOP' },
+			{ name: '선수B', position: 'MID' },
+			{ name: '선수C', position: 'TOP' },
+			{ name: '선수D', position: 'MID' }
+		],
+		teamIds: ['team-1', 'team-2']
+	};
+}
+
+describe('processPick', () => {
+	it('유효한 픽을 처리하고 갱신된 Draft를 반환한다', () => {
+		const draft = Draft.create(createConfig());
+		const result = processPick(draft, 'team-1', '선수A');
+		expect(result.draft.pickHistory).toHaveLength(1);
+		expect(result.draft.pickHistory[0]!.player.name).toBe('선수A');
+		expect(result.errorCode).toBeNull();
+	});
+
+	it('차례가 아닌 팀이 픽하면 에러 코드를 반환한다', () => {
+		const draft = Draft.create(createConfig());
+		const result = processPick(draft, 'team-2', '선수A');
+		expect(result.errorCode).toBe('NOT_YOUR_TURN');
+		expect(result.draft).toBe(draft);
+	});
+
+	it('이미 픽된 선수를 선택하면 에러 코드를 반환한다', () => {
+		const draft = Draft.create(createConfig());
+		const picked = processPick(draft, 'team-1', '선수A').draft;
+		const result = processPick(picked, 'team-2', '선수A');
+		expect(result.errorCode).toBe('PLAYER_NOT_FOUND');
+		expect(result.draft).toBe(picked);
+	});
+});
+
+describe('processAutoPick', () => {
+	it('remainingPool[0]을 자동 선택한다', () => {
+		const draft = Draft.create(createConfig());
+		const next = processAutoPick(draft);
+		expect(next.pickHistory).toHaveLength(1);
+		expect(next.pickHistory[0]!.player.name).toBe('선수A');
+	});
+
+	it('모든 픽이 완료되면 COMPLETED 상태가 된다', () => {
+		let draft = Draft.create(createConfig());
+		draft = processAutoPick(draft);
+		draft = processAutoPick(draft);
+		draft = processAutoPick(draft);
+		draft = processAutoPick(draft);
+		expect(draft.isCompleted).toBe(true);
+	});
+});

--- a/src/lib/domain/rule-engine/draft-driver.ts
+++ b/src/lib/domain/rule-engine/draft-driver.ts
@@ -1,0 +1,26 @@
+import type { Draft } from '$lib/domain/rule-engine/draft';
+import type { DraftErrorCode } from '$lib/domain/rule-engine/draft-errors';
+import { DraftError } from '$lib/domain/rule-engine/draft-errors';
+
+interface PickResultType {
+	readonly draft: Draft;
+	readonly errorCode: DraftErrorCode | null;
+}
+
+/** 픽 시도 — 성공 시 갱신된 Draft, 실패 시 에러 코드 */
+export function processPick(draft: Draft, teamId: string, playerName: string): PickResultType {
+	try {
+		const next = draft.pick(teamId, playerName);
+		return { draft: next, errorCode: null };
+	} catch (e) {
+		if (e instanceof DraftError) {
+			return { draft, errorCode: e.code };
+		}
+		throw e;
+	}
+}
+
+/** 타이머 만료 처리 — remainingPool[0] 자동 선택 */
+export function processAutoPick(draft: Draft): Draft {
+	return draft.autoPick();
+}

--- a/src/lib/domain/template/index.ts
+++ b/src/lib/domain/template/index.ts
@@ -1,7 +1,12 @@
 export { Template } from './template.ts';
 export { Player } from './player.ts';
+export { POSITIONS_BY_GAME } from './types.ts';
 export type {
 	GameType,
+	GamePositionType,
+	LeaguePositionType,
+	ValorantPositionType,
+	OverwatchPositionType,
 	TemplateModeType,
 	DraftModeType,
 	TierType,

--- a/src/lib/domain/template/types.ts
+++ b/src/lib/domain/template/types.ts
@@ -10,6 +10,41 @@ export type DraftModeType = 'SEQUENTIAL' | 'SNAKE';
 /** 선수 등급 */
 export type TierType = 'S+' | 'S' | 'A+' | 'A' | 'B+' | 'B' | 'C+' | 'C' | 'D+' | 'D';
 
+/** 종목별 포지션 */
+export type LeaguePositionType = 'TOP' | 'JUNGLE' | 'MID' | 'ADC' | 'SUPPORT';
+export type ValorantPositionType = 'DUELIST' | 'INITIATOR' | 'CONTROLLER' | 'SENTINEL';
+export type OverwatchPositionType = 'TANK' | 'DPS' | 'SUPPORT';
+
+export type GamePositionType = LeaguePositionType | ValorantPositionType | OverwatchPositionType;
+
+interface PositionOptionType {
+	readonly value: GamePositionType;
+	readonly label: string;
+}
+
+/** 종목별 포지션 목록 */
+export const POSITIONS_BY_GAME: Record<GameType, readonly PositionOptionType[]> = {
+	LEAGUE_OF_LEGENDS: [
+		{ value: 'TOP', label: 'TOP' },
+		{ value: 'JUNGLE', label: 'JGL' },
+		{ value: 'MID', label: 'MID' },
+		{ value: 'ADC', label: 'ADC' },
+		{ value: 'SUPPORT', label: 'SUP' }
+	],
+	VALORANT: [
+		{ value: 'DUELIST', label: 'DUE' },
+		{ value: 'INITIATOR', label: 'INI' },
+		{ value: 'CONTROLLER', label: 'CON' },
+		{ value: 'SENTINEL', label: 'SEN' }
+	],
+	OVERWATCH_2: [
+		{ value: 'TANK', label: 'TANK' },
+		{ value: 'DPS', label: 'DPS' },
+		{ value: 'SUPPORT', label: 'SUP' }
+	],
+	BATTLEGROUNDS: []
+};
+
 export interface PlayerParams {
 	readonly name: string;
 	readonly position: string;

--- a/src/lib/features/draft/stores/draft-store.svelte.ts
+++ b/src/lib/features/draft/stores/draft-store.svelte.ts
@@ -1,0 +1,76 @@
+// src/lib/features/draft/stores/draft-store.svelte.ts
+import { Draft } from '$lib/domain/rule-engine/draft';
+import type { DraftConfig } from '$lib/domain/rule-engine/draft-types';
+import type { UIPhaseType, CaptainType } from '../types';
+
+class DraftStore {
+	draft = $state<Draft>(null!);
+	uiPhase = $state<UIPhaseType>('READY');
+	endTime = $state<number | null>(null);
+	errorCode = $state<string | null>(null);
+	captains = $state<CaptainType[]>([]);
+	pickBanTime = $state<number>(30);
+	positionFilter = $state<string>('ALL');
+
+	/** 현재 차례 팀의 감독 이름 */
+	get currentCaptainName(): string | null {
+		const teamId = this.draft?.currentTeamId;
+		if (!teamId) return null;
+		const teamIndex = this.draft.config.teamIds.indexOf(teamId);
+		return this.captains[teamIndex]?.name ?? null;
+	}
+
+	/** 현재 라운드 */
+	get currentRound(): number {
+		return this.draft?.currentRound ?? 1;
+	}
+
+	/** 완료 여부 */
+	get isCompleted(): boolean {
+		return this.draft?.isCompleted ?? false;
+	}
+
+	/** 총 픽 수 */
+	get totalPicks(): number {
+		return this.draft?.pickOrder.length ?? 0;
+	}
+
+	/** 현재 픽 번호 (1-indexed) */
+	get currentPickNumber(): number {
+		return (this.draft?.currentPickIndex ?? 0) + 1;
+	}
+
+	/** 초기화 */
+	init(config: DraftConfig, captains: CaptainType[], pickBanTime: number): void {
+		this.draft = Draft.create(config);
+		this.captains = captains;
+		this.pickBanTime = pickBanTime;
+		this.uiPhase = 'READY';
+		this.endTime = null;
+		this.errorCode = null;
+		this.positionFilter = 'ALL';
+	}
+
+	/** Draft 인스턴스 교체 (불변 모델이므로 매번 새 인스턴스) */
+	updateDraft(next: Draft): void {
+		this.draft = next;
+	}
+
+	setUIPhase(phase: UIPhaseType): void {
+		this.uiPhase = phase;
+	}
+
+	setEndTime(endTime: number | null): void {
+		this.endTime = endTime;
+	}
+
+	setError(code: string | null): void {
+		this.errorCode = code;
+	}
+
+	setPositionFilter(position: string): void {
+		this.positionFilter = position;
+	}
+}
+
+export const draftStore = new DraftStore();

--- a/src/lib/features/draft/types.ts
+++ b/src/lib/features/draft/types.ts
@@ -1,0 +1,19 @@
+// src/lib/features/draft/types.ts
+
+/** 드래프트 페이지 UI 단계 */
+export type UIPhaseType = 'READY' | 'PLAYING' | 'FINISHED';
+
+/** 감독(팀 리더) 정보 — MSW 응답에서 변환 */
+export interface CaptainType {
+	readonly id: string;
+	readonly name: string;
+}
+
+/** 에러 코드 → 한글 메시지 매핑 (UI 레이어) */
+export const DRAFT_ERROR_MESSAGES: Record<string, string> = {
+	NOT_PICKING_PHASE: '드래프트가 진행 중이 아닙니다',
+	NOT_YOUR_TURN: '현재 차례가 아닙니다',
+	PLAYER_NOT_FOUND: '선수를 찾을 수 없습니다',
+	TEAM_NOT_FOUND: '팀을 찾을 수 없습니다',
+	DRAFT_ALREADY_COMPLETED: '드래프트가 완료되었습니다'
+};

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -78,10 +78,10 @@ export function createTemplateDetailResponse(
 		pickBanTime: 5,
 		players: [
 			{ name: 'KIIN', position: 'TOP', displayOrder: 0 },
-			{ name: 'ONER', position: 'JGL', displayOrder: 1 },
+			{ name: 'ONER', position: 'JUNGLE', displayOrder: 1 },
 			{ name: 'CHOVY', position: 'MID', displayOrder: 2 },
 			{ name: 'PEYZ', position: 'ADC', displayOrder: 3 },
-			{ name: 'LEHENDS', position: 'SUP', displayOrder: 4 }
+			{ name: 'LEHENDS', position: 'SUPPORT', displayOrder: 4 }
 		],
 		...overrides
 	});
@@ -101,10 +101,10 @@ export function createDraftTemplateDetailResponse(
 			{ name: 'Kiin', position: 'TOP', displayOrder: 1 },
 			{ name: 'Doran', position: 'TOP', displayOrder: 2 },
 			{ name: 'DuDu', position: 'TOP', displayOrder: 3 },
-			{ name: 'Oner', position: 'JGL', displayOrder: 4 },
-			{ name: 'Canyon', position: 'JGL', displayOrder: 5 },
-			{ name: 'Peanut', position: 'JGL', displayOrder: 6 },
-			{ name: 'Lucid', position: 'JGL', displayOrder: 7 },
+			{ name: 'Oner', position: 'JUNGLE', displayOrder: 4 },
+			{ name: 'Canyon', position: 'JUNGLE', displayOrder: 5 },
+			{ name: 'Peanut', position: 'JUNGLE', displayOrder: 6 },
+			{ name: 'Lucid', position: 'JUNGLE', displayOrder: 7 },
 			{ name: 'Faker', position: 'MID', displayOrder: 8 },
 			{ name: 'Chovy', position: 'MID', displayOrder: 9 },
 			{ name: 'Zeka', position: 'MID', displayOrder: 10 },
@@ -113,10 +113,10 @@ export function createDraftTemplateDetailResponse(
 			{ name: 'Peyz', position: 'ADC', displayOrder: 13 },
 			{ name: 'Viper', position: 'ADC', displayOrder: 14 },
 			{ name: 'Aiming', position: 'ADC', displayOrder: 15 },
-			{ name: 'Keria', position: 'SUP', displayOrder: 16 },
-			{ name: 'Lehends', position: 'SUP', displayOrder: 17 },
-			{ name: 'Delight', position: 'SUP', displayOrder: 18 },
-			{ name: 'BeryL', position: 'SUP', displayOrder: 19 }
+			{ name: 'Keria', position: 'SUPPORT', displayOrder: 16 },
+			{ name: 'Lehends', position: 'SUPPORT', displayOrder: 17 },
+			{ name: 'Delight', position: 'SUPPORT', displayOrder: 18 },
+			{ name: 'BeryL', position: 'SUPPORT', displayOrder: 19 }
 		],
 		...overrides
 	});

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -87,6 +87,41 @@ export function createTemplateDetailResponse(
 	});
 }
 
+export function createDraftTemplateDetailResponse(
+	overrides?: Partial<TemplateResponse>
+): TemplateResponse {
+	return createTemplateResponse({
+		mode: 'DRAFT',
+		teamCount: 4,
+		teamSize: 5,
+		draftOrderStrategy: 'SNAKE',
+		pickBanTime: 30,
+		players: [
+			{ name: 'Zeus', position: 'TOP', displayOrder: 0 },
+			{ name: 'Kiin', position: 'TOP', displayOrder: 1 },
+			{ name: 'Doran', position: 'TOP', displayOrder: 2 },
+			{ name: 'DuDu', position: 'TOP', displayOrder: 3 },
+			{ name: 'Oner', position: 'JGL', displayOrder: 4 },
+			{ name: 'Canyon', position: 'JGL', displayOrder: 5 },
+			{ name: 'Peanut', position: 'JGL', displayOrder: 6 },
+			{ name: 'Lucid', position: 'JGL', displayOrder: 7 },
+			{ name: 'Faker', position: 'MID', displayOrder: 8 },
+			{ name: 'Chovy', position: 'MID', displayOrder: 9 },
+			{ name: 'Zeka', position: 'MID', displayOrder: 10 },
+			{ name: 'ShowMaker', position: 'MID', displayOrder: 11 },
+			{ name: 'Gumayusi', position: 'ADC', displayOrder: 12 },
+			{ name: 'Peyz', position: 'ADC', displayOrder: 13 },
+			{ name: 'Viper', position: 'ADC', displayOrder: 14 },
+			{ name: 'Aiming', position: 'ADC', displayOrder: 15 },
+			{ name: 'Keria', position: 'SUP', displayOrder: 16 },
+			{ name: 'Lehends', position: 'SUP', displayOrder: 17 },
+			{ name: 'Delight', position: 'SUP', displayOrder: 18 },
+			{ name: 'BeryL', position: 'SUP', displayOrder: 19 }
+		],
+		...overrides
+	});
+}
+
 // ─── Room ───
 
 function createTeamLeaders(count: number, budget: number): TeamLeaderResponse[] {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import {
 	success,
 	createTemplateListResponse,
 	createTemplateDetailResponse,
+	createDraftTemplateDetailResponse,
 	createTemplateResponse,
 	createRoomResponse,
 	createRoomSessionResponse,
@@ -83,6 +84,16 @@ export const handlers = [
 	http.get(`${BASE_URL}/api/v1/solo/auction/:templateId`, ({ params }) => {
 		const id = params['templateId'] as string;
 		const template = createTemplateDetailResponse({ id });
+		const captains = Array.from({ length: template.teamCount }, (_, i) => ({
+			id: `captain-${i + 1}`,
+			name: `감독 ${i + 1}`
+		}));
+		return HttpResponse.json(success({ template, captains }));
+	}),
+
+	http.get(`${BASE_URL}/api/v1/solo/draft/:templateId`, ({ params }) => {
+		const id = params['templateId'] as string;
+		const template = createDraftTemplateDetailResponse({ id });
 		const captains = Array.from({ length: template.teamCount }, (_, i) => ({
 			id: `captain-${i + 1}`,
 			name: `감독 ${i + 1}`

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -13,7 +13,6 @@
 	import { SvelteSet } from 'svelte/reactivity';
 
 	const store = draftStore;
-	const positions = ['ALL', 'TOP', 'JGL', 'MID', 'ADC', 'SUP'];
 
 	let remainingSeconds = $state(0);
 	let timerInterval: ReturnType<typeof setInterval> | null = null;
@@ -149,6 +148,13 @@
 	);
 
 	const timerProgress = $derived(store.pickBanTime > 0 ? remainingSeconds / store.pickBanTime : 0);
+
+	/** 선수풀에서 고유 포지션 추출 (순서 유지) */
+	const positions = $derived(() => {
+		if (!store.draft) return ['ALL'];
+		const unique = [...new Set(store.draft.config.playerPool.map((p) => p.position))];
+		return ['ALL', ...unique];
+	});
 
 	const filteredPool = $derived(
 		store.draft
@@ -410,7 +416,7 @@
 
 				<!-- 포지션 필터 탭 -->
 				<div class="mt-4 flex">
-					{#each positions as pos (pos)}
+					{#each positions() as pos (pos)}
 						<button
 							type="button"
 							class="flex h-11 w-24 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -403,8 +403,7 @@
 					<div
 						class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-base font-semibold text-bg-primary"
 					>
-						<span>→</span>
-						<span class="tracking-wider">내 픽 — {store.currentCaptainName}</span>
+						<span class="tracking-wider">{store.currentCaptainName} 님의 차례입니다.</span>
 						<span class="ml-auto tracking-wider">선수를 선택하세요</span>
 					</div>
 				{/if}

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -215,7 +215,7 @@
 		<span class="font-mono text-base text-muted">로딩 중...</span>
 	</div>
 {:else}
-	<div class="relative flex h-screen flex-col bg-bg-primary">
+	<div class="relative h-screen">
 		<!-- Dim Overlay: READY -->
 		{#if store.uiPhase === 'READY'}
 			<div
@@ -228,7 +228,7 @@
 					<h2 id="overlay-ready-title" class="font-heading text-3xl font-bold text-gray-50">
 						드래프트를 시작합니다
 					</h2>
-					<Button variant="PRIMARY" size="MD" onclick={handleStart}>시작</Button>
+					<Button variant="PRIMARY" size="MD" onclick={handleStart} autofocus>시작</Button>
 				</div>
 			</div>
 		{/if}
@@ -245,258 +245,282 @@
 					<h2 id="overlay-finished-title" class="font-heading text-3xl font-bold text-gray-50">
 						드래프트가 종료되었습니다
 					</h2>
-					<Button variant="PRIMARY" size="MD" onclick={() => goto(`/result/${$page.params['id']}`)}>
+					<Button
+						variant="PRIMARY"
+						size="MD"
+						onclick={() => goto(`/result/${$page.params['id']}`)}
+						autofocus
+					>
 						결과 보기
 					</Button>
 				</div>
 			</div>
 		{/if}
 
-		<!-- Top Bar -->
-		<header class="flex h-[60px] items-center justify-between border-b border-gray-700 px-8">
-			<div class="flex items-center gap-4">
-				<span class="h-2 w-2 rounded-full bg-accent"></span>
-				<span class="font-mono text-sm font-semibold tracking-[2px] text-accent">솔로 드래프트</span
+		<div
+			class="flex h-full flex-col bg-bg-primary"
+			inert={store.uiPhase === 'READY' || store.uiPhase === 'FINISHED' ? true : undefined}
+		>
+			<h1 class="sr-only">드래프트방</h1>
+			<!-- Top Bar -->
+			<header class="flex h-[60px] items-center justify-between border-b border-gray-700 px-8">
+				<div class="flex items-center gap-4">
+					<span class="h-2 w-2 rounded-full bg-accent" aria-hidden="true"></span>
+					<span class="font-mono text-sm font-semibold tracking-[2px] text-accent"
+						>솔로 드래프트</span
+					>
+				</div>
+				<div class="flex items-center gap-3">
+					<span class="font-mono text-sm font-semibold tracking-wider text-muted">
+						라운드 {store.currentRound}
+					</span>
+					<span class="font-mono text-sm text-muted">—</span>
+					<span class="font-mono text-sm font-semibold tracking-wider text-gray-50">
+						픽 {String(store.currentPickNumber).padStart(2, '0')} / {String(
+							store.totalPicks
+						).padStart(2, '0')}
+					</span>
+					<Badge variant="STATUS">LIVE</Badge>
+				</div>
+				<span class="font-mono text-sm font-semibold text-gray-50">{timerDisplay}</span>
+			</header>
+
+			<!-- Body -->
+			<div class="flex flex-1 overflow-hidden">
+				<!-- Left Panel: 팀 로스터 -->
+				<aside
+					aria-label="팀 로스터"
+					class="flex w-[280px] flex-col gap-4 overflow-y-auto border-r border-gray-700 px-5 py-6"
 				>
-			</div>
-			<div class="flex items-center gap-3">
-				<span class="font-mono text-sm font-semibold tracking-wider text-muted">
-					라운드 {store.currentRound}
-				</span>
-				<span class="font-mono text-sm text-muted">—</span>
-				<span class="font-mono text-sm font-semibold tracking-wider text-gray-50">
-					픽 {String(store.currentPickNumber).padStart(2, '0')} / {String(
-						store.totalPicks
-					).padStart(2, '0')}
-				</span>
-				<Badge variant="STATUS">LIVE</Badge>
-			</div>
-			<span class="font-mono text-sm font-semibold text-gray-50">{timerDisplay}</span>
-		</header>
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">팀 로스터</span>
 
-		<!-- Body -->
-		<div class="flex flex-1 overflow-hidden">
-			<!-- Left Panel: 팀 로스터 -->
-			<aside
-				class="flex w-[280px] flex-col gap-4 overflow-y-auto border-r border-gray-700 px-5 py-6"
-			>
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">팀 로스터</span>
-
-				{#each store.draft.teams as team, i (team.id)}
-					{@const captain = store.captains[i]}
-					{@const isCurrent = team.id === store.draft.currentTeamId}
-					{@const slotsNeeded = store.draft.config.rounds}
-					{@const isExpanded = expandedTeams.has(team.id)}
-					{@const hasOverflow = team.roster.length > PREVIEW_COUNT}
-					{@const visibleRoster = isExpanded ? team.roster : team.roster.slice(0, PREVIEW_COUNT)}
-					<div class="flex flex-col gap-1.5 {i > 0 ? 'pt-3' : ''}">
-						<!-- 팀 헤더 -->
-						<div class="flex items-center justify-between">
-							<span
-								class="font-heading text-base font-semibold {isCurrent
-									? 'text-accent'
-									: 'text-gray-50'}"
-							>
-								{captain?.name ?? `팀 ${i + 1}`}
-							</span>
-							<div class="flex items-center gap-2">
-								<span class="font-mono text-sm text-muted">
-									{team.roster.length}/{slotsNeeded}
+					{#each store.draft.teams as team, i (team.id)}
+						{@const captain = store.captains[i]}
+						{@const isCurrent = team.id === store.draft.currentTeamId}
+						{@const slotsNeeded = store.draft.config.rounds}
+						{@const isExpanded = expandedTeams.has(team.id)}
+						{@const hasOverflow = team.roster.length > PREVIEW_COUNT}
+						{@const visibleRoster = isExpanded ? team.roster : team.roster.slice(0, PREVIEW_COUNT)}
+						<div class="flex flex-col gap-1.5 {i > 0 ? 'pt-3' : ''}">
+							<!-- 팀 헤더 -->
+							<div class="flex items-center justify-between">
+								<span
+									class="font-heading text-base font-semibold {isCurrent
+										? 'text-accent'
+										: 'text-gray-50'}"
+								>
+									{captain?.name ?? `팀 ${i + 1}`}
 								</span>
-								{#if isCurrent}
-									<span class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent">
-										내 차례
+								<div class="flex items-center gap-2">
+									<span class="font-mono text-sm text-muted">
+										{team.roster.length}/{slotsNeeded}
 									</span>
-								{/if}
-							</div>
-						</div>
-
-						<!-- 선수 세로 리스트 -->
-						{#if team.roster.length > 0}
-							<div class="flex flex-col gap-1">
-								{#each visibleRoster as player, si (si)}
-									<div
-										class="flex items-center gap-2 border px-3 py-1.5 {isCurrent
-											? 'border-gray-700 bg-accent-20'
-											: 'border-gray-700'}"
-									>
-										<span class="w-10 font-mono text-xs text-muted">{player.position}</span>
-										<span class="flex-1 truncate font-heading text-sm font-semibold text-gray-50">
-											{player.name}
+									{#if isCurrent}
+										<span
+											class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent"
+										>
+											내 차례
 										</span>
+									{/if}
+								</div>
+							</div>
+
+							<!-- 선수 세로 리스트 -->
+							{#if team.roster.length > 0}
+								<ul class="flex flex-col gap-1">
+									{#each visibleRoster as player, si (si)}
+										<li
+											class="flex items-center gap-2 border px-3 py-1.5 {isCurrent
+												? 'border-gray-700 bg-accent-20'
+												: 'border-gray-700'}"
+										>
+											<span class="w-10 font-mono text-xs text-muted">{player.position}</span>
+											<span class="flex-1 truncate font-heading text-sm font-semibold text-gray-50">
+												{player.name}
+											</span>
+										</li>
+									{/each}
+									{#if hasOverflow}
+										<li>
+											<button
+												type="button"
+												class="flex w-full items-center justify-center py-1 font-mono text-xs text-muted hover:text-accent"
+												onclick={() => toggleTeamExpand(team.id)}
+											>
+												{#if isExpanded}
+													접기
+												{:else}
+													… 외 {team.roster.length - PREVIEW_COUNT}명 더보기
+												{/if}
+											</button>
+										</li>
+									{/if}
+								</ul>
+							{:else}
+								<span class="font-mono text-xs text-dim">선수 없음</span>
+							{/if}
+						</div>
+					{/each}
+				</aside>
+
+				<!-- Main Content -->
+				<main id="main-content" class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
+					<!-- 타이머 (대형) -->
+					<div class="flex flex-col items-center gap-2">
+						<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">남은 시간</span>
+						<span
+							aria-live="off"
+							aria-label={`남은 시간 ${timerDisplay}`}
+							class="font-heading text-6xl font-bold text-accent">{timerDisplay}</span
+						>
+						<div
+							role="progressbar"
+							aria-label="드래프트 타이머 진행률"
+							aria-valuenow={remainingSeconds}
+							aria-valuemin={0}
+							aria-valuemax={store.pickBanTime}
+							class="h-1 w-full max-w-md bg-gray-700"
+						>
+							<div class="h-full bg-accent" style="width: {timerProgress * 100}%"></div>
+						</div>
+					</div>
+
+					<!-- 드래프트 순서 -->
+					<div class="mt-5 flex flex-col gap-2">
+						<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
+							드래프트 순서
+						</span>
+						<ol class="flex items-center gap-1 overflow-x-auto">
+							{#each draftOrderDisplay as d, i (i)}
+								<li
+									class="flex h-11 w-[96px] shrink-0 items-center justify-center border {d.current
+										? 'border-accent'
+										: 'border-gray-700'}"
+								>
+									<div class="flex flex-col items-center">
+										<span
+											class="font-mono text-sm font-semibold {d.current
+												? 'text-accent'
+												: d.done
+													? 'text-gray-50'
+													: 'text-muted'}"
+										>
+											{d.teamName}
+										</span>
+										<span class="font-mono text-xs text-muted">{d.pick}</span>
 									</div>
-								{/each}
-								{#if hasOverflow}
+								</li>
+							{/each}
+						</ol>
+					</div>
+
+					<!-- 현재 턴 배너 -->
+					{#if store.draft.currentTeamId}
+						<div
+							class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-base font-semibold text-bg-primary"
+						>
+							<span class="tracking-wider">{store.currentCaptainName} 님의 차례입니다.</span>
+							<span class="ml-auto tracking-wider">선수를 선택하세요</span>
+						</div>
+					{/if}
+
+					<!-- 에러 메시지 -->
+					{#if errorMessage}
+						<span role="alert" class="mt-2 font-mono text-sm text-red-400">{errorMessage}</span>
+					{/if}
+
+					<!-- 포지션 필터 탭 -->
+					<div role="radiogroup" aria-label="포지션 필터" class="mt-4 flex">
+						{#each positions() as pos (pos)}
+							<button
+								type="button"
+								role="radio"
+								aria-checked={store.positionFilter === pos}
+								class="flex h-11 w-24 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===
+								pos
+									? 'bg-accent text-bg-primary'
+									: 'border border-gray-700 text-muted'}"
+								onclick={() => handlePositionFilter(pos)}
+							>
+								{pos}
+							</button>
+						{/each}
+					</div>
+
+					<!-- 선수 그리드 -->
+					<div class="mt-4 flex flex-1 flex-col gap-2 overflow-y-auto">
+						{#each playerRows() as row, ri (ri)}
+							<div class="flex gap-2">
+								{#each row as player (player.name)}
 									<button
 										type="button"
-										class="flex items-center justify-center py-1 font-mono text-xs text-muted hover:text-accent"
-										onclick={() => toggleTeamExpand(team.id)}
+										class="flex h-28 flex-1 flex-col justify-center gap-2 border border-gray-700 px-5 py-4 text-left hover:border-accent"
+										onclick={() => handlePickPlayer(player.name)}
+										disabled={store.uiPhase !== 'PLAYING'}
 									>
-										{#if isExpanded}
-											접기
-										{:else}
-											… 외 {team.roster.length - PREVIEW_COUNT}명 더보기
-										{/if}
+										<span class="font-mono text-sm font-semibold tracking-wider text-accent">
+											{player.position}
+										</span>
+										<span class="font-heading text-lg font-semibold text-gray-50">
+											{player.name}
+										</span>
 									</button>
-								{/if}
-							</div>
-						{:else}
-							<span class="font-mono text-xs text-dim">선수 없음</span>
-						{/if}
-					</div>
-				{/each}
-			</aside>
-
-			<!-- Main Content -->
-			<main id="main-content" class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
-				<!-- 타이머 (대형) -->
-				<div class="flex flex-col items-center gap-2">
-					<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">남은 시간</span>
-					<span
-						aria-live="off"
-						aria-label={`남은 시간 ${timerDisplay}`}
-						class="font-heading text-6xl font-bold text-accent">{timerDisplay}</span
-					>
-					<div
-						role="progressbar"
-						aria-label="드래프트 타이머 진행률"
-						aria-valuenow={remainingSeconds}
-						aria-valuemin={0}
-						aria-valuemax={store.pickBanTime}
-						class="h-1 w-full max-w-md bg-gray-700"
-					>
-						<div class="h-full bg-accent" style="width: {timerProgress * 100}%"></div>
-					</div>
-				</div>
-
-				<!-- 드래프트 순서 -->
-				<div class="mt-5 flex flex-col gap-2">
-					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
-						드래프트 순서
-					</span>
-					<div class="flex items-center gap-1 overflow-x-auto">
-						{#each draftOrderDisplay as d, i (i)}
-							<div
-								class="flex h-11 w-[96px] shrink-0 items-center justify-center border {d.current
-									? 'border-accent'
-									: 'border-gray-700'}"
-							>
-								<div class="flex flex-col items-center">
-									<span
-										class="font-mono text-sm font-semibold {d.current
-											? 'text-accent'
-											: d.done
-												? 'text-gray-50'
-												: 'text-muted'}"
-									>
-										{d.teamName}
-									</span>
-									<span class="font-mono text-xs text-muted">{d.pick}</span>
-								</div>
+								{/each}
+								<!-- 빈 셀로 행 폭 맞추기 -->
+								{#each Array(5 - row.length) as _item}
+									<div class="flex-1"></div>
+								{/each}
 							</div>
 						{/each}
 					</div>
-				</div>
+				</main>
 
-				<!-- 현재 턴 배너 -->
-				{#if store.draft.currentTeamId}
-					<div
-						class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-base font-semibold text-bg-primary"
-					>
-						<span class="tracking-wider">{store.currentCaptainName} 님의 차례입니다.</span>
-						<span class="ml-auto tracking-wider">선수를 선택하세요</span>
-					</div>
-				{/if}
-
-				<!-- 에러 메시지 -->
-				{#if errorMessage}
-					<span role="alert" class="mt-2 font-mono text-sm text-red-400">{errorMessage}</span>
-				{/if}
-
-				<!-- 포지션 필터 탭 -->
-				<div class="mt-4 flex">
-					{#each positions() as pos (pos)}
-						<button
-							type="button"
-							class="flex h-11 w-24 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===
-							pos
-								? 'bg-accent text-bg-primary'
-								: 'border border-gray-700 text-muted'}"
-							onclick={() => handlePositionFilter(pos)}
-						>
-							{pos}
-						</button>
-					{/each}
-				</div>
-
-				<!-- 선수 그리드 -->
-				<div class="mt-4 flex flex-1 flex-col gap-2 overflow-y-auto">
-					{#each playerRows() as row, ri (ri)}
-						<div class="flex gap-2">
-							{#each row as player (player.name)}
-								<button
-									type="button"
-									class="flex h-28 flex-1 flex-col justify-center gap-2 border border-gray-700 px-5 py-4 text-left hover:border-accent"
-									onclick={() => handlePickPlayer(player.name)}
-									disabled={store.uiPhase !== 'PLAYING'}
-								>
-									<span class="font-mono text-sm font-semibold tracking-wider text-accent">
-										{player.position}
+				<!-- Right Panel: 픽 히스토리 -->
+				<aside
+					aria-label="픽 히스토리"
+					class="flex w-[280px] flex-col gap-3 overflow-y-auto border-l border-gray-700 px-5 py-6"
+				>
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
+						픽 히스토리
+					</span>
+					<ol class="flex flex-col gap-3">
+						{#each store.draft.pickHistory as record, i (i)}
+							{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
+							{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
+							<li class="flex items-center gap-3">
+								<span class="font-mono text-sm font-semibold text-dim">
+									{String(i + 1).padStart(2, '0')}
+								</span>
+								<div class="flex flex-col gap-0.5">
+									<span class="font-heading text-sm font-semibold text-gray-50">
+										{record.player.name}
 									</span>
-									<span class="font-heading text-lg font-semibold text-gray-50">
-										{player.name}
+									<span class="font-mono text-xs text-muted">
+										{record.player.position} → {captainName}
 									</span>
-								</button>
-							{/each}
-							<!-- 빈 셀로 행 폭 맞추기 -->
-							{#each Array(5 - row.length) as _item}
-								<div class="flex-1"></div>
-							{/each}
-						</div>
-					{/each}
-				</div>
-			</main>
+								</div>
+							</li>
+						{/each}
 
-			<!-- Right Panel: 픽 히스토리 -->
-			<aside
-				class="flex w-[280px] flex-col gap-3 overflow-y-auto border-l border-gray-700 px-5 py-6"
-			>
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
-					픽 히스토리
-				</span>
-				{#each store.draft.pickHistory as record, i (i)}
-					{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
-					{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
-					<div class="flex items-center gap-3">
-						<span class="font-mono text-sm font-semibold text-dim">
-							{String(i + 1).padStart(2, '0')}
-						</span>
-						<div class="flex flex-col gap-0.5">
-							<span class="font-heading text-sm font-semibold text-gray-50">
-								{record.player.name}
-							</span>
-							<span class="font-mono text-xs text-muted">
-								{record.player.position} → {captainName}
-							</span>
-						</div>
-					</div>
-				{/each}
-
-				<!-- 현재 진행 중 표시 -->
-				{#if store.draft.currentTeamId}
-					{@const currentTeamIndex = store.draft.config.teamIds.indexOf(store.draft.currentTeamId)}
-					{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
-					<div class="flex items-center gap-3">
-						<span class="font-mono text-sm font-semibold text-accent">
-							{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
-						</span>
-						<div class="flex flex-col gap-0.5">
-							<span class="font-heading text-sm font-semibold text-accent">—</span>
-							<span class="font-mono text-xs text-muted">{currentName} 선택 중</span>
-						</div>
-					</div>
-				{/if}
-			</aside>
+						<!-- 현재 진행 중 표시 -->
+						{#if store.draft.currentTeamId}
+							{@const currentTeamIndex = store.draft.config.teamIds.indexOf(
+								store.draft.currentTeamId
+							)}
+							{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
+							<li class="flex items-center gap-3">
+								<span class="font-mono text-sm font-semibold text-accent">
+									{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
+								</span>
+								<div class="flex flex-col gap-0.5">
+									<span class="font-heading text-sm font-semibold text-accent">—</span>
+									<span class="font-mono text-xs text-muted">{currentName} 선택 중</span>
+								</div>
+							</li>
+						{/if}
+					</ol>
+				</aside>
+			</div>
 		</div>
 	</div>
 {/if}

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -1,303 +1,446 @@
 <script lang="ts">
-	import { Icon } from '$lib/components';
+	import { onDestroy, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { Badge, Button } from '$lib/components';
+	import { draftStore } from '$lib/features/draft/stores/draft-store.svelte';
+	import { processPick, processAutoPick } from '$lib/domain/rule-engine/draft-driver';
+	import { calcRemaining, createEndTime } from '$lib/utils/countdown';
+	import { DRAFT_ERROR_MESSAGES } from '$lib/features/draft/types';
+	import type { DraftConfig } from '$lib/domain/rule-engine/draft-types';
+	import type { CaptainType } from '$lib/features/draft/types';
+	import { apiGet } from '$lib/utils/api-client';
 
-	const draftOrder = [
-		{ team: 'T1', pick: '1st', done: true },
-		{ team: 'GEN', pick: '2nd', done: true },
-		{ team: 'HLE', pick: '3rd', done: false, current: true },
-		{ team: 'DK', pick: '4th', done: false },
-		{ team: 'T1', pick: '5th', done: false },
-		{ team: 'DK', pick: '6th', done: false },
-		{ team: 'HLE', pick: '7th', done: false }
-	];
+	const store = draftStore;
+	const positions = ['ALL', 'TOP', 'JGL', 'MID', 'ADC', 'SUP'];
 
-	const positions = ['ALL', 'TOP', 'JG', 'MID', 'ADC', 'SUP'];
+	let remainingSeconds = $state(0);
+	let timerInterval: ReturnType<typeof setInterval> | null = null;
+	let loading = $state(true);
 
-	const players = [
-		[
-			{ pos: 'TOP', name: 'Zeus', team: 'T1' },
-			{ pos: 'JGL', name: 'Oner', team: 'T1' },
-			{ pos: 'MID', name: 'Faker', team: 'T1', selected: true },
-			{ pos: 'ADC', name: 'Gumayusi', team: 'T1' },
-			{ pos: 'SUP', name: 'Keria', team: 'T1' }
-		],
-		[
-			{ pos: 'TOP', name: 'Kiin', team: 'DK' },
-			{ pos: 'JGL', name: 'Canyon', team: 'DK' },
-			{ pos: 'MID', name: 'Chovy', team: 'GEN' },
-			{ pos: 'ADC', name: 'Peyz', team: 'GEN' },
-			{ pos: 'SUP', name: 'Lehends', team: 'GEN' }
-		],
-		[
-			{ pos: 'TOP', name: 'Doran', team: 'HLE' },
-			{ pos: 'JGL', name: 'Peanut', team: 'HLE' },
-			{ pos: 'MID', name: 'Zeka', team: 'HLE' },
-			{ pos: 'ADC', name: 'Viper', team: 'HLE' },
-			{ pos: 'SUP', name: 'Delight', team: 'HLE' }
-		],
-		[
-			{ pos: 'MID', name: 'BdDu', team: 'KT' },
-			{ pos: 'JGL', name: 'Lucid', team: 'KT' },
-			{ pos: 'MID', name: 'ShowMaker', team: 'DK' },
-			{ pos: 'SUP', name: 'Aiming', team: 'KT' },
-			{ pos: 'SUP', name: 'BeryL', team: 'DK' }
-		]
-	];
+	// ─── Timer ───
 
-	interface Slot {
-		filled: boolean;
-		name?: string;
-		pos?: string;
-		current?: boolean;
-	}
-
-	interface Team {
-		name: string;
-		count: string;
-		current: boolean;
-		badge?: string;
-		slots: Slot[];
-	}
-
-	const teams: Team[] = [
-		{
-			name: 'T1',
-			count: '1/5',
-			current: false,
-			slots: [
-				{ filled: true, name: 'Zeus', pos: 'TOP' },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false }
-			]
-		},
-		{
-			name: 'GEN',
-			count: '1/5',
-			current: false,
-			slots: [
-				{ filled: true, name: 'Chovy', pos: 'MID' },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false }
-			]
-		},
-		{
-			name: 'HLE',
-			count: '0/5',
-			current: true,
-			badge: '내 차례',
-			slots: [
-				{ filled: false, current: true },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false }
-			]
-		},
-		{
-			name: 'DK',
-			count: '0/5',
-			current: false,
-			slots: [
-				{ filled: false },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false },
-				{ filled: false }
-			]
+	function tickTimer(): void {
+		if (!store.endTime) return;
+		remainingSeconds = calcRemaining(store.endTime);
+		if (remainingSeconds <= 0) {
+			stopTimer();
+			handleTimerExpiry();
 		}
-	];
+	}
 
-	const pickHistory = [
-		{ num: '01', name: 'Zeus', team: 'T1 → T1', done: true },
-		{ num: '02', name: 'Chovy', team: 'GEN → GEN', done: true },
-		{ num: '03', name: '—', team: 'HLE 선택 중', done: false, current: true },
-		{ num: '04', name: '—', team: 'DK 대기', done: false }
-	];
+	function startTimer(): void {
+		const endTime = createEndTime(store.pickBanTime);
+		store.setEndTime(endTime);
+		remainingSeconds = store.pickBanTime;
+		timerInterval = setInterval(tickTimer, 100);
+	}
+
+	function stopTimer(): void {
+		if (timerInterval) {
+			clearInterval(timerInterval);
+			timerInterval = null;
+		}
+	}
+
+	// ─── Handlers ───
+
+	function handleTimerExpiry(): void {
+		const next = processAutoPick(store.draft);
+		store.updateDraft(next);
+
+		if (next.isCompleted) {
+			store.setUIPhase('FINISHED');
+			store.setEndTime(null);
+		} else {
+			startTimer();
+		}
+	}
+
+	function handleStart(): void {
+		store.setUIPhase('PLAYING');
+		startTimer();
+	}
+
+	function handlePickPlayer(playerName: string): void {
+		if (store.uiPhase !== 'PLAYING') return;
+
+		const teamId = store.draft.currentTeamId;
+		if (!teamId) return;
+
+		const result = processPick(store.draft, teamId, playerName);
+		if (result.errorCode) {
+			store.setError(result.errorCode);
+			return;
+		}
+
+		store.updateDraft(result.draft);
+		store.setError(null);
+
+		if (result.draft.isCompleted) {
+			stopTimer();
+			store.setUIPhase('FINISHED');
+			store.setEndTime(null);
+		} else {
+			stopTimer();
+			startTimer();
+		}
+	}
+
+	function handlePositionFilter(position: string): void {
+		store.setPositionFilter(position);
+	}
+
+	// ─── Lifecycle ───
+
+	onMount(async () => {
+		try {
+			const templateId = $page.params['id'];
+			const data = await apiGet<{
+				template: {
+					teamCount: number;
+					teamSize: number;
+					draftOrderStrategy: 'SNAKE' | 'FIXED';
+					pickBanTime: number;
+					players: { name: string; position: string; displayOrder: number }[];
+				};
+				captains: CaptainType[];
+			}>(globalThis.fetch, `/api/v1/solo/draft/${templateId}`);
+
+			const t = data.template;
+			const captains = data.captains;
+			const teamIds = captains.map((c) => c.id);
+			const rounds = Math.floor(t.players.length / t.teamCount);
+
+			const config: DraftConfig = {
+				teamCount: t.teamCount,
+				draftType: t.draftOrderStrategy === 'SNAKE' ? 'SNAKE' : 'SEQUENTIAL',
+				rounds,
+				playerPool: t.players.map((p) => ({ name: p.name, position: p.position })),
+				teamIds
+			};
+
+			store.init(config, captains, t.pickBanTime ?? 30);
+			loading = false;
+		} catch (e) {
+			console.error('드래프트 데이터 로드 실패', e);
+			loading = false;
+		}
+	});
+
+	onDestroy(() => {
+		stopTimer();
+	});
+
+	// ─── Derived ───
+
+	const timerDisplay = $derived(
+		`${String(Math.floor(remainingSeconds / 60)).padStart(2, '0')}:${String(remainingSeconds % 60).padStart(2, '0')}`
+	);
+
+	const filteredPool = $derived(
+		store.draft
+			? store.positionFilter === 'ALL'
+				? store.draft.remainingPool
+				: store.draft.remainingPool.filter((p) => p.position === store.positionFilter)
+			: []
+	);
+
+	const errorMessage = $derived(
+		store.errorCode ? (DRAFT_ERROR_MESSAGES[store.errorCode] ?? store.errorCode) : null
+	);
+
+	/** 선수풀을 5열 그리드 행으로 변환 */
+	const playerRows = $derived(() => {
+		const rows: (typeof filteredPool)[] = [];
+		for (let i = 0; i < filteredPool.length; i += 5) {
+			rows.push(filteredPool.slice(i, i + 5));
+		}
+		return rows;
+	});
+
+	/** 드래프트 순서 표시용 */
+	const draftOrderDisplay = $derived(
+		store.draft
+			? store.draft.pickOrder.map((teamId, i) => {
+					const teamIndex = store.draft.config.teamIds.indexOf(teamId);
+					const captain = store.captains[teamIndex];
+					return {
+						teamName: captain?.name ?? `팀 ${teamIndex + 1}`,
+						pick: `${i + 1}`,
+						done: i < store.draft.currentPickIndex,
+						current: i === store.draft.currentPickIndex
+					};
+				})
+			: []
+	);
 </script>
 
 <svelte:head>
 	<title>드래프트방 | Fantazzk</title>
 </svelte:head>
 
-<div class="flex h-screen flex-col bg-bg-primary">
-	<!-- Top Bar -->
-	<header class="flex h-16 items-center justify-between border-b border-gray-700 px-8">
-		<span class="font-heading text-xl font-bold tracking-wider text-accent">
-			LCK 2026 모의 드래프트
-		</span>
-		<div class="flex items-center gap-6">
-			<span class="font-mono text-xs font-semibold tracking-wider text-muted">라운드 1</span>
-			<span class="font-mono text-xs font-semibold tracking-wider text-gray-50"> 픽 3 / 10 </span>
-		</div>
-		<div class="flex items-center gap-2">
-			<Icon name="settings" size={16} color="#C9A962" />
-			<span class="font-heading text-2xl font-bold text-accent">00:27</span>
-		</div>
-	</header>
+<a
+	href="#main-content"
+	class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-2 focus:text-accent"
+	>본문으로 바로가기</a
+>
 
-	<!-- Body -->
-	<div class="flex flex-1 overflow-hidden">
-		<!-- Main Content -->
-		<main class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
-			<!-- 드래프트 순서 -->
-			<div class="flex flex-col gap-2">
-				<span class="font-mono text-xs font-semibold tracking-wider text-muted">
-					드래프트 순서
-				</span>
-				<div class="flex items-center gap-1">
-					{#each draftOrder as d, i (i)}
-						{#if i === 5}
-							<span class="px-1 text-muted">
-								<Icon name="settings" size={16} color="#777777" />
-							</span>
-						{/if}
-						<div
-							class="flex h-10 w-[88px] items-center justify-center border {d.current
-								? 'border-accent'
-								: 'border-gray-700'}"
-						>
-							<div class="flex flex-col items-center">
-								<span
-									class="font-mono text-xs font-semibold {d.current
-										? 'text-accent'
-										: d.done
-											? 'text-gray-50'
-											: 'text-muted'}"
-								>
-									{d.team}
-								</span>
-								<span class="font-mono text-xs text-muted">{d.pick}</span>
-							</div>
-						</div>
-					{/each}
+{#if loading}
+	<div
+		role="status"
+		aria-live="polite"
+		class="flex h-screen items-center justify-center bg-bg-primary"
+	>
+		<span class="font-mono text-sm text-muted">로딩 중...</span>
+	</div>
+{:else}
+	<div class="relative flex h-screen flex-col bg-bg-primary">
+		<!-- Dim Overlay: READY -->
+		{#if store.uiPhase === 'READY'}
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="overlay-ready-title"
+				class="absolute inset-0 z-50 flex items-center justify-center bg-black/70"
+			>
+				<div class="flex flex-col items-center gap-6">
+					<h2 id="overlay-ready-title" class="font-heading text-2xl font-bold text-gray-50">
+						드래프트를 시작합니다
+					</h2>
+					<Button variant="PRIMARY" size="MD" onclick={handleStart}>시작</Button>
 				</div>
 			</div>
+		{/if}
 
-			<!-- 현재 턴 배너 -->
+		<!-- Dim Overlay: FINISHED -->
+		{#if store.uiPhase === 'FINISHED'}
 			<div
-				class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-sm font-semibold text-bg-primary"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="overlay-finished-title"
+				class="absolute inset-0 z-50 flex items-center justify-center bg-black/70"
 			>
-				<span>→</span>
-				<span class="tracking-wider">내 픽 — 한화생명 이스포츠</span>
-				<span class="ml-auto tracking-wider">선수를 선택하세요</span>
+				<div class="flex flex-col items-center gap-6">
+					<h2 id="overlay-finished-title" class="font-heading text-2xl font-bold text-gray-50">
+						드래프트가 종료되었습니다
+					</h2>
+					<Button variant="PRIMARY" size="MD" onclick={() => goto(`/result/${$page.params['id']}`)}>
+						결과 보기
+					</Button>
+				</div>
 			</div>
+		{/if}
 
-			<!-- 포지션 필터 탭 -->
-			<div class="mt-4 flex">
-				{#each positions as pos, i (i)}
-					<button
-						class="flex h-10 w-20 items-center justify-center font-mono text-sm font-semibold tracking-wider {i ===
-						0
-							? 'bg-accent text-bg-primary'
-							: 'border border-gray-700 text-muted'}"
-					>
-						{pos}
-					</button>
-				{/each}
+		<!-- Top Bar -->
+		<header class="flex h-[60px] items-center justify-between border-b border-gray-700 px-8">
+			<div class="flex items-center gap-4">
+				<span class="h-2 w-2 rounded-full bg-accent"></span>
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">솔로 드래프트</span
+				>
 			</div>
+			<div class="flex items-center gap-3">
+				<span class="font-mono text-xs font-semibold tracking-wider text-muted">
+					라운드 {store.currentRound}
+				</span>
+				<span class="font-mono text-xs text-muted">—</span>
+				<span class="font-mono text-xs font-semibold tracking-wider text-gray-50">
+					픽 {String(store.currentPickNumber).padStart(2, '0')} / {String(
+						store.totalPicks
+					).padStart(2, '0')}
+				</span>
+				<Badge variant="STATUS">LIVE</Badge>
+			</div>
+			<span class="font-mono text-xs font-semibold text-gray-50">{timerDisplay}</span>
+		</header>
 
-			<!-- 선수 그리드 -->
-			<div class="mt-4 flex flex-1 flex-col gap-2 overflow-y-auto">
-				{#each players as row, ri (ri)}
-					<div class="flex gap-2">
-						{#each row as p, ci (ci)}
+		<!-- Body -->
+		<div class="flex flex-1 overflow-hidden">
+			<!-- Main Content -->
+			<main id="main-content" class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
+				<!-- 드래프트 순서 -->
+				<div class="flex flex-col gap-2">
+					<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">
+						드래프트 순서
+					</span>
+					<div class="flex items-center gap-1 overflow-x-auto">
+						{#each draftOrderDisplay as d, i (i)}
 							<div
-								class="flex h-28 flex-1 flex-col justify-center gap-2 border px-5 py-4 {p.selected
+								class="flex h-10 w-[88px] shrink-0 items-center justify-center border {d.current
 									? 'border-accent'
 									: 'border-gray-700'}"
 							>
-								<span class="font-mono text-sm font-semibold tracking-wider text-accent">
-									{p.pos}
-								</span>
-								<span class="font-heading text-lg font-semibold text-gray-50">
-									{p.name}
-								</span>
-								<span class="font-mono text-sm text-muted">{p.team}</span>
-							</div>
-						{/each}
-					</div>
-				{/each}
-			</div>
-		</main>
-
-		<!-- Side Panel: 팀 로스터 -->
-		<aside class="flex w-[320px] flex-col gap-4 overflow-y-auto border-l border-gray-700 px-5 py-6">
-			<span class="font-mono text-sm font-semibold tracking-wider text-accent"> 팀 로스터 </span>
-
-			{#each teams as t, i (i)}
-				<div class="flex flex-col gap-2 {i > 0 ? 'pt-3' : ''}">
-					<div class="flex items-center justify-between">
-						<span
-							class="font-heading text-base font-semibold {t.current
-								? 'text-accent'
-								: 'text-gray-50'}"
-						>
-							{t.name}
-						</span>
-						<div class="flex items-center gap-2">
-							<span class="font-mono text-xs text-muted">{t.count}</span>
-							{#if t.badge}
-								<span class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent">
-									{t.badge}
-								</span>
-							{/if}
-						</div>
-					</div>
-					<div class="flex gap-1">
-						{#each t.slots as s, si (si)}
-							<div
-								class="flex h-9 flex-1 items-center justify-center border {s.current
-									? 'border-accent'
-									: 'border-gray-700'} {s.filled ? 'bg-accent-20' : ''}"
-							>
-								{#if s.filled}
-									<span class="font-mono text-xs font-semibold text-gray-50">
-										{s.name}
+								<div class="flex flex-col items-center">
+									<span
+										class="font-mono text-xs font-semibold {d.current
+											? 'text-accent'
+											: d.done
+												? 'text-gray-50'
+												: 'text-muted'}"
+									>
+										{d.teamName}
 									</span>
-								{/if}
+									<span class="font-mono text-xs text-muted">{d.pick}</span>
+								</div>
 							</div>
 						{/each}
 					</div>
 				</div>
-			{/each}
 
-			<div class="h-px w-full bg-gray-700"></div>
+				<!-- 현재 턴 배너 -->
+				{#if store.draft.currentTeamId}
+					<div
+						class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-sm font-semibold text-bg-primary"
+					>
+						<span>→</span>
+						<span class="tracking-wider">내 픽 — {store.currentCaptainName}</span>
+						<span class="ml-auto tracking-wider">선수를 선택하세요</span>
+					</div>
+				{/if}
 
-			<!-- 픽 히스토리 -->
-			<div class="flex flex-col gap-3">
-				<span class="font-mono text-sm font-semibold tracking-wider text-accent">
-					픽 히스토리
-				</span>
-				{#each pickHistory as h, i (i)}
-					<div class="flex items-center gap-3">
-						<span
-							class="font-mono text-xs font-semibold {h.current
-								? 'text-accent'
-								: h.done
-									? 'text-dim'
-									: 'text-gray-700'}"
+				<!-- 에러 메시지 -->
+				{#if errorMessage}
+					<span role="alert" class="mt-2 font-mono text-xs text-red-400">{errorMessage}</span>
+				{/if}
+
+				<!-- 포지션 필터 탭 -->
+				<div class="mt-4 flex">
+					{#each positions as pos (pos)}
+						<button
+							type="button"
+							class="flex h-10 w-20 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===
+							pos
+								? 'bg-accent text-bg-primary'
+								: 'border border-gray-700 text-muted'}"
+							onclick={() => handlePositionFilter(pos)}
 						>
-							{h.num}
-						</span>
-						<div class="flex flex-col gap-0.5">
+							{pos}
+						</button>
+					{/each}
+				</div>
+
+				<!-- 선수 그리드 -->
+				<div class="mt-4 flex flex-1 flex-col gap-2 overflow-y-auto">
+					{#each playerRows() as row, ri (ri)}
+						<div class="flex gap-2">
+							{#each row as player (player.name)}
+								<button
+									type="button"
+									class="flex h-28 flex-1 flex-col justify-center gap-2 border border-gray-700 px-5 py-4 text-left hover:border-accent"
+									onclick={() => handlePickPlayer(player.name)}
+									disabled={store.uiPhase !== 'PLAYING'}
+								>
+									<span class="font-mono text-sm font-semibold tracking-wider text-accent">
+										{player.position}
+									</span>
+									<span class="font-heading text-lg font-semibold text-gray-50">
+										{player.name}
+									</span>
+								</button>
+							{/each}
+							<!-- 빈 셀로 행 폭 맞추기 -->
+							{#each Array(5 - row.length) as _item}
+								<div class="flex-1"></div>
+							{/each}
+						</div>
+					{/each}
+				</div>
+			</main>
+
+			<!-- Side Panel: 팀 로스터 + 픽 히스토리 -->
+			<aside
+				class="flex w-[320px] flex-col gap-4 overflow-y-auto border-l border-gray-700 px-5 py-6"
+			>
+				<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">팀 로스터</span
+				>
+
+				{#each store.draft.teams as team, i (team.id)}
+					{@const captain = store.captains[i]}
+					{@const isCurrent = team.id === store.draft.currentTeamId}
+					{@const slotsNeeded = store.draft.config.rounds}
+					<div class="flex flex-col gap-2 {i > 0 ? 'pt-3' : ''}">
+						<div class="flex items-center justify-between">
 							<span
-								class="font-heading text-sm font-semibold {h.current
+								class="font-heading text-base font-semibold {isCurrent
 									? 'text-accent'
-									: h.done
-										? 'text-gray-50'
-										: 'text-muted'}"
+									: 'text-gray-50'}"
 							>
-								{h.name}
+								{captain?.name ?? `팀 ${i + 1}`}
 							</span>
-							<span class="font-mono text-xs text-muted">{h.team}</span>
+							<div class="flex items-center gap-2">
+								<span class="font-mono text-xs text-muted">
+									{team.roster.length}/{slotsNeeded}
+								</span>
+								{#if isCurrent}
+									<span class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent">
+										내 차례
+									</span>
+								{/if}
+							</div>
+						</div>
+						<div class="flex gap-1">
+							{#each Array(slotsNeeded) as _item, si (si)}
+								{@const filled = team.roster[si]}
+								<div
+									class="flex h-9 flex-1 items-center justify-center border {isCurrent &&
+									si === team.roster.length
+										? 'border-accent'
+										: 'border-gray-700'} {filled ? 'bg-accent-20' : ''}"
+								>
+									{#if filled}
+										<span class="font-mono text-xs font-semibold text-gray-50">
+											{filled.name}
+										</span>
+									{/if}
+								</div>
+							{/each}
 						</div>
 					</div>
 				{/each}
-			</div>
-		</aside>
+
+				<div class="h-px w-full bg-gray-700"></div>
+
+				<!-- 픽 히스토리 -->
+				<div class="flex flex-col gap-3">
+					<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">
+						픽 히스토리
+					</span>
+					{#each store.draft.pickHistory as record, i (i)}
+						{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
+						{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
+						<div class="flex items-center gap-3">
+							<span class="font-mono text-xs font-semibold text-dim">
+								{String(i + 1).padStart(2, '0')}
+							</span>
+							<div class="flex flex-col gap-0.5">
+								<span class="font-heading text-sm font-semibold text-gray-50">
+									{record.player.name}
+								</span>
+								<span class="font-mono text-xs text-muted">
+									{record.player.position} → {captainName}
+								</span>
+							</div>
+						</div>
+					{/each}
+
+					<!-- 현재 진행 중 표시 -->
+					{#if store.draft.currentTeamId}
+						{@const currentTeamIndex = store.draft.config.teamIds.indexOf(
+							store.draft.currentTeamId
+						)}
+						{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
+						<div class="flex items-center gap-3">
+							<span class="font-mono text-xs font-semibold text-accent">
+								{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
+							</span>
+							<div class="flex flex-col gap-0.5">
+								<span class="font-heading text-sm font-semibold text-accent">—</span>
+								<span class="font-mono text-xs text-muted">{currentName} 선택 중</span>
+							</div>
+						</div>
+					{/if}
+				</div>
+			</aside>
+		</div>
 	</div>
-</div>
+{/if}

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -270,6 +270,77 @@
 
 		<!-- Body -->
 		<div class="flex flex-1 overflow-hidden">
+			<!-- Left Panel: 팀 로스터 -->
+			<aside
+				class="flex w-[280px] flex-col gap-4 overflow-y-auto border-r border-gray-700 px-5 py-6"
+			>
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">팀 로스터</span>
+
+				{#each store.draft.teams as team, i (team.id)}
+					{@const captain = store.captains[i]}
+					{@const isCurrent = team.id === store.draft.currentTeamId}
+					{@const slotsNeeded = store.draft.config.rounds}
+					{@const isExpanded = expandedTeams.has(team.id)}
+					{@const hasOverflow = team.roster.length > PREVIEW_COUNT}
+					{@const visibleRoster = isExpanded ? team.roster : team.roster.slice(0, PREVIEW_COUNT)}
+					<div class="flex flex-col gap-1.5 {i > 0 ? 'pt-3' : ''}">
+						<!-- 팀 헤더 -->
+						<div class="flex items-center justify-between">
+							<span
+								class="font-heading text-base font-semibold {isCurrent
+									? 'text-accent'
+									: 'text-gray-50'}"
+							>
+								{captain?.name ?? `팀 ${i + 1}`}
+							</span>
+							<div class="flex items-center gap-2">
+								<span class="font-mono text-sm text-muted">
+									{team.roster.length}/{slotsNeeded}
+								</span>
+								{#if isCurrent}
+									<span class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent">
+										내 차례
+									</span>
+								{/if}
+							</div>
+						</div>
+
+						<!-- 선수 세로 리스트 -->
+						{#if team.roster.length > 0}
+							<div class="flex flex-col gap-1">
+								{#each visibleRoster as player, si (si)}
+									<div
+										class="flex items-center gap-2 border px-3 py-1.5 {isCurrent
+											? 'border-gray-700 bg-accent-20'
+											: 'border-gray-700'}"
+									>
+										<span class="w-10 font-mono text-xs text-muted">{player.position}</span>
+										<span class="flex-1 truncate font-heading text-sm font-semibold text-gray-50">
+											{player.name}
+										</span>
+									</div>
+								{/each}
+								{#if hasOverflow}
+									<button
+										type="button"
+										class="flex items-center justify-center py-1 font-mono text-xs text-muted hover:text-accent"
+										onclick={() => toggleTeamExpand(team.id)}
+									>
+										{#if isExpanded}
+											접기
+										{:else}
+											… 외 {team.roster.length - PREVIEW_COUNT}명 더보기
+										{/if}
+									</button>
+								{/if}
+							</div>
+						{:else}
+							<span class="font-mono text-xs text-dim">선수 없음</span>
+						{/if}
+					</div>
+				{/each}
+			</aside>
+
 			<!-- Main Content -->
 			<main id="main-content" class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
 				<!-- 타이머 (대형) -->
@@ -381,118 +452,45 @@
 				</div>
 			</main>
 
-			<!-- Side Panel: 팀 로스터 + 픽 히스토리 -->
+			<!-- Right Panel: 픽 히스토리 -->
 			<aside
-				class="flex w-[340px] flex-col gap-4 overflow-y-auto border-l border-gray-700 px-5 py-6"
+				class="flex w-[280px] flex-col gap-3 overflow-y-auto border-l border-gray-700 px-5 py-6"
 			>
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">팀 로스터</span>
-
-				{#each store.draft.teams as team, i (team.id)}
-					{@const captain = store.captains[i]}
-					{@const isCurrent = team.id === store.draft.currentTeamId}
-					{@const slotsNeeded = store.draft.config.rounds}
-					{@const isExpanded = expandedTeams.has(team.id)}
-					{@const hasOverflow = team.roster.length > PREVIEW_COUNT}
-					{@const visibleRoster = isExpanded ? team.roster : team.roster.slice(0, PREVIEW_COUNT)}
-					<div class="flex flex-col gap-1.5 {i > 0 ? 'pt-3' : ''}">
-						<!-- 팀 헤더 -->
-						<div class="flex items-center justify-between">
-							<span
-								class="font-heading text-base font-semibold {isCurrent
-									? 'text-accent'
-									: 'text-gray-50'}"
-							>
-								{captain?.name ?? `팀 ${i + 1}`}
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
+					픽 히스토리
+				</span>
+				{#each store.draft.pickHistory as record, i (i)}
+					{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
+					{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
+					<div class="flex items-center gap-3">
+						<span class="font-mono text-sm font-semibold text-dim">
+							{String(i + 1).padStart(2, '0')}
+						</span>
+						<div class="flex flex-col gap-0.5">
+							<span class="font-heading text-sm font-semibold text-gray-50">
+								{record.player.name}
 							</span>
-							<div class="flex items-center gap-2">
-								<span class="font-mono text-sm text-muted">
-									{team.roster.length}/{slotsNeeded}
-								</span>
-								{#if isCurrent}
-									<span class="bg-accent-20 px-2 py-1 font-mono text-xs font-semibold text-accent">
-										내 차례
-									</span>
-								{/if}
-							</div>
+							<span class="font-mono text-xs text-muted">
+								{record.player.position} → {captainName}
+							</span>
 						</div>
-
-						<!-- 선수 세로 리스트 -->
-						{#if team.roster.length > 0}
-							<div class="flex flex-col gap-1">
-								{#each visibleRoster as player, si (si)}
-									<div
-										class="flex items-center gap-2 border px-3 py-1.5 {isCurrent
-											? 'border-gray-700 bg-accent-20'
-											: 'border-gray-700'}"
-									>
-										<span class="w-10 font-mono text-xs text-muted">{player.position}</span>
-										<span class="flex-1 truncate font-heading text-sm font-semibold text-gray-50">
-											{player.name}
-										</span>
-									</div>
-								{/each}
-								{#if hasOverflow}
-									<button
-										type="button"
-										class="flex items-center justify-center py-1 font-mono text-xs text-muted hover:text-accent"
-										onclick={() => toggleTeamExpand(team.id)}
-									>
-										{#if isExpanded}
-											접기
-										{:else}
-											… 외 {team.roster.length - PREVIEW_COUNT}명 더보기
-										{/if}
-									</button>
-								{/if}
-							</div>
-						{:else}
-							<span class="font-mono text-xs text-dim">선수 없음</span>
-						{/if}
 					</div>
 				{/each}
 
-				<div class="h-px w-full bg-gray-700"></div>
-
-				<!-- 픽 히스토리 -->
-				<div class="flex flex-col gap-3">
-					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
-						픽 히스토리
-					</span>
-					{#each store.draft.pickHistory as record, i (i)}
-						{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
-						{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
-						<div class="flex items-center gap-3">
-							<span class="font-mono text-sm font-semibold text-dim">
-								{String(i + 1).padStart(2, '0')}
-							</span>
-							<div class="flex flex-col gap-0.5">
-								<span class="font-heading text-sm font-semibold text-gray-50">
-									{record.player.name}
-								</span>
-								<span class="font-mono text-xs text-muted">
-									{record.player.position} → {captainName}
-								</span>
-							</div>
+				<!-- 현재 진행 중 표시 -->
+				{#if store.draft.currentTeamId}
+					{@const currentTeamIndex = store.draft.config.teamIds.indexOf(store.draft.currentTeamId)}
+					{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
+					<div class="flex items-center gap-3">
+						<span class="font-mono text-sm font-semibold text-accent">
+							{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
+						</span>
+						<div class="flex flex-col gap-0.5">
+							<span class="font-heading text-sm font-semibold text-accent">—</span>
+							<span class="font-mono text-xs text-muted">{currentName} 선택 중</span>
 						</div>
-					{/each}
-
-					<!-- 현재 진행 중 표시 -->
-					{#if store.draft.currentTeamId}
-						{@const currentTeamIndex = store.draft.config.teamIds.indexOf(
-							store.draft.currentTeamId
-						)}
-						{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
-						<div class="flex items-center gap-3">
-							<span class="font-mono text-sm font-semibold text-accent">
-								{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
-							</span>
-							<div class="flex flex-col gap-0.5">
-								<span class="font-heading text-sm font-semibold text-accent">—</span>
-								<span class="font-mono text-xs text-muted">{currentName} 선택 중</span>
-							</div>
-						</div>
-					{/if}
-				</div>
+					</div>
+				{/if}
 			</aside>
 		</div>
 	</div>

--- a/src/routes/draft/[id]/+page.svelte
+++ b/src/routes/draft/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import type { DraftConfig } from '$lib/domain/rule-engine/draft-types';
 	import type { CaptainType } from '$lib/features/draft/types';
 	import { apiGet } from '$lib/utils/api-client';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	const store = draftStore;
 	const positions = ['ALL', 'TOP', 'JGL', 'MID', 'ADC', 'SUP'];
@@ -17,6 +18,7 @@
 	let remainingSeconds = $state(0);
 	let timerInterval: ReturnType<typeof setInterval> | null = null;
 	let loading = $state(true);
+	let expandedTeams = $state<SvelteSet<string>>(new SvelteSet());
 
 	// ─── Timer ───
 
@@ -91,6 +93,14 @@
 		store.setPositionFilter(position);
 	}
 
+	function toggleTeamExpand(teamId: string): void {
+		if (expandedTeams.has(teamId)) {
+			expandedTeams.delete(teamId);
+		} else {
+			expandedTeams.add(teamId);
+		}
+	}
+
 	// ─── Lifecycle ───
 
 	onMount(async () => {
@@ -138,6 +148,8 @@
 		`${String(Math.floor(remainingSeconds / 60)).padStart(2, '0')}:${String(remainingSeconds % 60).padStart(2, '0')}`
 	);
 
+	const timerProgress = $derived(store.pickBanTime > 0 ? remainingSeconds / store.pickBanTime : 0);
+
 	const filteredPool = $derived(
 		store.draft
 			? store.positionFilter === 'ALL'
@@ -174,6 +186,8 @@
 				})
 			: []
 	);
+
+	const PREVIEW_COUNT = 3;
 </script>
 
 <svelte:head>
@@ -192,7 +206,7 @@
 		aria-live="polite"
 		class="flex h-screen items-center justify-center bg-bg-primary"
 	>
-		<span class="font-mono text-sm text-muted">로딩 중...</span>
+		<span class="font-mono text-base text-muted">로딩 중...</span>
 	</div>
 {:else}
 	<div class="relative flex h-screen flex-col bg-bg-primary">
@@ -205,7 +219,7 @@
 				class="absolute inset-0 z-50 flex items-center justify-center bg-black/70"
 			>
 				<div class="flex flex-col items-center gap-6">
-					<h2 id="overlay-ready-title" class="font-heading text-2xl font-bold text-gray-50">
+					<h2 id="overlay-ready-title" class="font-heading text-3xl font-bold text-gray-50">
 						드래프트를 시작합니다
 					</h2>
 					<Button variant="PRIMARY" size="MD" onclick={handleStart}>시작</Button>
@@ -222,7 +236,7 @@
 				class="absolute inset-0 z-50 flex items-center justify-center bg-black/70"
 			>
 				<div class="flex flex-col items-center gap-6">
-					<h2 id="overlay-finished-title" class="font-heading text-2xl font-bold text-gray-50">
+					<h2 id="overlay-finished-title" class="font-heading text-3xl font-bold text-gray-50">
 						드래프트가 종료되었습니다
 					</h2>
 					<Button variant="PRIMARY" size="MD" onclick={() => goto(`/result/${$page.params['id']}`)}>
@@ -236,43 +250,63 @@
 		<header class="flex h-[60px] items-center justify-between border-b border-gray-700 px-8">
 			<div class="flex items-center gap-4">
 				<span class="h-2 w-2 rounded-full bg-accent"></span>
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">솔로 드래프트</span
+				<span class="font-mono text-sm font-semibold tracking-[2px] text-accent">솔로 드래프트</span
 				>
 			</div>
 			<div class="flex items-center gap-3">
-				<span class="font-mono text-xs font-semibold tracking-wider text-muted">
+				<span class="font-mono text-sm font-semibold tracking-wider text-muted">
 					라운드 {store.currentRound}
 				</span>
-				<span class="font-mono text-xs text-muted">—</span>
-				<span class="font-mono text-xs font-semibold tracking-wider text-gray-50">
+				<span class="font-mono text-sm text-muted">—</span>
+				<span class="font-mono text-sm font-semibold tracking-wider text-gray-50">
 					픽 {String(store.currentPickNumber).padStart(2, '0')} / {String(
 						store.totalPicks
 					).padStart(2, '0')}
 				</span>
 				<Badge variant="STATUS">LIVE</Badge>
 			</div>
-			<span class="font-mono text-xs font-semibold text-gray-50">{timerDisplay}</span>
+			<span class="font-mono text-sm font-semibold text-gray-50">{timerDisplay}</span>
 		</header>
 
 		<!-- Body -->
 		<div class="flex flex-1 overflow-hidden">
 			<!-- Main Content -->
 			<main id="main-content" class="flex flex-1 flex-col overflow-y-auto px-8 py-6">
+				<!-- 타이머 (대형) -->
+				<div class="flex flex-col items-center gap-2">
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">남은 시간</span>
+					<span
+						aria-live="off"
+						aria-label={`남은 시간 ${timerDisplay}`}
+						class="font-heading text-6xl font-bold text-accent">{timerDisplay}</span
+					>
+					<div
+						role="progressbar"
+						aria-label="드래프트 타이머 진행률"
+						aria-valuenow={remainingSeconds}
+						aria-valuemin={0}
+						aria-valuemax={store.pickBanTime}
+						class="h-1 w-full max-w-md bg-gray-700"
+					>
+						<div class="h-full bg-accent" style="width: {timerProgress * 100}%"></div>
+					</div>
+				</div>
+
 				<!-- 드래프트 순서 -->
-				<div class="flex flex-col gap-2">
-					<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">
+				<div class="mt-5 flex flex-col gap-2">
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
 						드래프트 순서
 					</span>
 					<div class="flex items-center gap-1 overflow-x-auto">
 						{#each draftOrderDisplay as d, i (i)}
 							<div
-								class="flex h-10 w-[88px] shrink-0 items-center justify-center border {d.current
+								class="flex h-11 w-[96px] shrink-0 items-center justify-center border {d.current
 									? 'border-accent'
 									: 'border-gray-700'}"
 							>
 								<div class="flex flex-col items-center">
 									<span
-										class="font-mono text-xs font-semibold {d.current
+										class="font-mono text-sm font-semibold {d.current
 											? 'text-accent'
 											: d.done
 												? 'text-gray-50'
@@ -290,7 +324,7 @@
 				<!-- 현재 턴 배너 -->
 				{#if store.draft.currentTeamId}
 					<div
-						class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-sm font-semibold text-bg-primary"
+						class="mt-4 flex h-14 items-center gap-3 bg-accent px-5 font-mono text-base font-semibold text-bg-primary"
 					>
 						<span>→</span>
 						<span class="tracking-wider">내 픽 — {store.currentCaptainName}</span>
@@ -300,7 +334,7 @@
 
 				<!-- 에러 메시지 -->
 				{#if errorMessage}
-					<span role="alert" class="mt-2 font-mono text-xs text-red-400">{errorMessage}</span>
+					<span role="alert" class="mt-2 font-mono text-sm text-red-400">{errorMessage}</span>
 				{/if}
 
 				<!-- 포지션 필터 탭 -->
@@ -308,7 +342,7 @@
 					{#each positions as pos (pos)}
 						<button
 							type="button"
-							class="flex h-10 w-20 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===
+							class="flex h-11 w-24 items-center justify-center font-mono text-sm font-semibold tracking-wider {store.positionFilter ===
 							pos
 								? 'bg-accent text-bg-primary'
 								: 'border border-gray-700 text-muted'}"
@@ -349,16 +383,19 @@
 
 			<!-- Side Panel: 팀 로스터 + 픽 히스토리 -->
 			<aside
-				class="flex w-[320px] flex-col gap-4 overflow-y-auto border-l border-gray-700 px-5 py-6"
+				class="flex w-[340px] flex-col gap-4 overflow-y-auto border-l border-gray-700 px-5 py-6"
 			>
-				<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">팀 로스터</span
-				>
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">팀 로스터</span>
 
 				{#each store.draft.teams as team, i (team.id)}
 					{@const captain = store.captains[i]}
 					{@const isCurrent = team.id === store.draft.currentTeamId}
 					{@const slotsNeeded = store.draft.config.rounds}
-					<div class="flex flex-col gap-2 {i > 0 ? 'pt-3' : ''}">
+					{@const isExpanded = expandedTeams.has(team.id)}
+					{@const hasOverflow = team.roster.length > PREVIEW_COUNT}
+					{@const visibleRoster = isExpanded ? team.roster : team.roster.slice(0, PREVIEW_COUNT)}
+					<div class="flex flex-col gap-1.5 {i > 0 ? 'pt-3' : ''}">
+						<!-- 팀 헤더 -->
 						<div class="flex items-center justify-between">
 							<span
 								class="font-heading text-base font-semibold {isCurrent
@@ -368,7 +405,7 @@
 								{captain?.name ?? `팀 ${i + 1}`}
 							</span>
 							<div class="flex items-center gap-2">
-								<span class="font-mono text-xs text-muted">
+								<span class="font-mono text-sm text-muted">
 									{team.roster.length}/{slotsNeeded}
 								</span>
 								{#if isCurrent}
@@ -378,23 +415,39 @@
 								{/if}
 							</div>
 						</div>
-						<div class="flex gap-1">
-							{#each Array(slotsNeeded) as _item, si (si)}
-								{@const filled = team.roster[si]}
-								<div
-									class="flex h-9 flex-1 items-center justify-center border {isCurrent &&
-									si === team.roster.length
-										? 'border-accent'
-										: 'border-gray-700'} {filled ? 'bg-accent-20' : ''}"
-								>
-									{#if filled}
-										<span class="font-mono text-xs font-semibold text-gray-50">
-											{filled.name}
+
+						<!-- 선수 세로 리스트 -->
+						{#if team.roster.length > 0}
+							<div class="flex flex-col gap-1">
+								{#each visibleRoster as player, si (si)}
+									<div
+										class="flex items-center gap-2 border px-3 py-1.5 {isCurrent
+											? 'border-gray-700 bg-accent-20'
+											: 'border-gray-700'}"
+									>
+										<span class="w-10 font-mono text-xs text-muted">{player.position}</span>
+										<span class="flex-1 truncate font-heading text-sm font-semibold text-gray-50">
+											{player.name}
 										</span>
-									{/if}
-								</div>
-							{/each}
-						</div>
+									</div>
+								{/each}
+								{#if hasOverflow}
+									<button
+										type="button"
+										class="flex items-center justify-center py-1 font-mono text-xs text-muted hover:text-accent"
+										onclick={() => toggleTeamExpand(team.id)}
+									>
+										{#if isExpanded}
+											접기
+										{:else}
+											… 외 {team.roster.length - PREVIEW_COUNT}명 더보기
+										{/if}
+									</button>
+								{/if}
+							</div>
+						{:else}
+							<span class="font-mono text-xs text-dim">선수 없음</span>
+						{/if}
 					</div>
 				{/each}
 
@@ -402,14 +455,14 @@
 
 				<!-- 픽 히스토리 -->
 				<div class="flex flex-col gap-3">
-					<span class="font-mono text-[11px] font-semibold tracking-[2px] text-accent">
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
 						픽 히스토리
 					</span>
 					{#each store.draft.pickHistory as record, i (i)}
 						{@const teamIndex = store.draft.config.teamIds.indexOf(record.teamId)}
 						{@const captainName = store.captains[teamIndex]?.name ?? `팀 ${teamIndex + 1}`}
 						<div class="flex items-center gap-3">
-							<span class="font-mono text-xs font-semibold text-dim">
+							<span class="font-mono text-sm font-semibold text-dim">
 								{String(i + 1).padStart(2, '0')}
 							</span>
 							<div class="flex flex-col gap-0.5">
@@ -430,7 +483,7 @@
 						)}
 						{@const currentName = store.captains[currentTeamIndex]?.name ?? ''}
 						<div class="flex items-center gap-3">
-							<span class="font-mono text-xs font-semibold text-accent">
+							<span class="font-mono text-sm font-semibold text-accent">
 								{String(store.draft.pickHistory.length + 1).padStart(2, '0')}
 							</span>
 							<div class="flex flex-col gap-0.5">

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -3,6 +3,7 @@
 	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
 	import { Template } from '$lib/domain/template';
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
+	import { POSITIONS_BY_GAME } from '$lib/domain/template';
 
 	// --- State ---
 	let name = $state('');
@@ -37,16 +38,9 @@
 		tier: TierType;
 	}
 
-	const ROLES_BY_GAME: Record<GameType, string[]> = {
-		LEAGUE_OF_LEGENDS: ['탑', '정글', '미드', '원딜', '서포터'],
-		VALORANT: ['듀얼리스트', '이니시에이터', '컨트롤러', '센티널'],
-		OVERWATCH_2: ['탱커', '딜러', '서포터'],
-		BATTLEGROUNDS: []
-	};
-
 	let players = $state<PlayerEntry[]>([]);
-	let roles = $derived(ROLES_BY_GAME[gameType]);
-	let hasRoles = $derived(roles.length > 0);
+	let positionOptions = $derived(POSITIONS_BY_GAME[gameType]);
+	let hasRoles = $derived(positionOptions.length > 0);
 
 	// --- Derived ---
 	let completion = $derived(
@@ -81,14 +75,14 @@
 	// --- Functions ---
 	function setGameType(gt: GameType) {
 		gameType = gt;
-		const newRoles = ROLES_BY_GAME[gt];
+		const newOptions = POSITIONS_BY_GAME[gt];
 		for (const player of players) {
-			player.position = newRoles.length > 0 ? newRoles[0]! : '';
+			player.position = newOptions.length > 0 ? newOptions[0]!.value : '';
 		}
 	}
 
 	function addPlayer() {
-		players.push({ name: '', position: hasRoles ? roles[0]! : '', tier: 'B' });
+		players.push({ name: '', position: hasRoles ? positionOptions[0]!.value : '', tier: 'B' });
 	}
 
 	function removePlayer(index: number) {
@@ -471,8 +465,8 @@
 													aria-label="선수 {i + 1} 역할"
 													class="h-10 w-[140px] border border-gray-700 bg-bg-primary px-3 font-mono text-sm text-gray-50 focus:border-accent focus:outline-none"
 												>
-													{#each roles as role}
-														<option value={role}>{role}</option>
+													{#each positionOptions as opt}
+														<option value={opt.value}>{opt.label}</option>
 													{/each}
 												</select>
 											{/if}

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
 	import { Template } from '$lib/domain/template';
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
@@ -17,6 +18,15 @@
 	let draftInfoRef = $state<HTMLElement | null>(null);
 	let activeStep = $state<number | null>(null);
 	let stepRefs = $state<(HTMLElement | null)[]>([null, null, null, null]);
+
+	function handleSoloPlay(): void {
+		const templateId = crypto.randomUUID();
+		if (mode === 'DRAFT') {
+			goto(`/draft/${templateId}`);
+		} else {
+			goto(`/auction/${templateId}`);
+		}
+	}
 
 	// --- 선수 관련 ---
 	const TIERS: TierType[] = ['S+', 'S', 'A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D'];
@@ -535,7 +545,7 @@
 
 				<!-- Bottom Bar -->
 				<div class="flex items-center justify-end gap-3 border-t border-gray-700 px-14 py-4">
-					<Button variant="SECONDARY" size="MD">혼자 하기</Button>
+					<Button variant="SECONDARY" size="MD" onclick={handleSoloPlay}>혼자 하기</Button>
 					<Button variant="PRIMARY" size="MD">방 만들기</Button>
 				</div>
 			</main>


### PR DESCRIPTION
## 변경 사항

- draft-driver 순수 함수 구현 (processPick, processAutoPick) + 테스트 5개
- DraftStore ($state 기반 반응형 상태) 및 feature 전용 타입 정의
- MSW 솔로 드래프트 mock API 추가 (/api/v1/solo/draft/:templateId)
- 드래프트 페이지 store/driver 연동 — 하드코딩 전면 제거
- 3패널 레이아웃 (좌: 팀 로스터, 중: 메인, 우: 픽 히스토리)
- 대형 타이머 + 프로그레스 바 (경매 페이지와 동일 패턴)
- 팀 로스터 세로 리스트 + 접기/펼치기 (3명 초과 시)
- 포지션 필터 탭 — 선수풀에서 동적 추출
- GamePositionType 도입 — 종목별 포지션 정형화, MSW mock position 값 통일
- 템플릿 생성 "혼자 하기" 버튼 → 드래프트/경매 모드 분기 진입

## 미완료 (TODO)

- [ ] 서버 API 필드 확장 대기 (fantazzk/server#66) — gameType, position, pickBanTime, minBidUnit, positionLimit
- [ ] 경매 페이지 MSW mock position 값도 GamePositionType으로 통일 (#2 작업 시)

## 테스트

- [x] `bun run check` 통과 (기존 에러 외 신규 에러 없음)
- [x] `bun test` 79 pass, 0 fail
- [x] 드래프트 페이지 수동 확인 — 시작 오버레이, 선수 픽, 타이머, 포지션 필터, 팀 로스터, 완료 오버레이