### PR TITLE
설정(배포): GCP Cloud Run 배포 파이프라인 구성 (#50)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,40 +1,37 @@
-name: Docker Build & Push
+name: Deploy to Cloud Run
 
 on:
   push:
     branches: [dev, main]
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: asia-northeast3
+  IMAGE: asia-northeast3-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/web-fe/app
 
 jobs:
-  build-and-push:
+  deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,7 +41,30 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Determine service name
+        id: service
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "name=web-fe" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=web-fe-dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ steps.service.outputs.name }}
+          image: ${{ env.IMAGE }}:${{ github.sha }}
+          region: ${{ env.REGION }}
+          flags: |
+            --port=3000
+            --cpu-boost
+            --min-instances=0
+            --max-instances=10
+            --allow-unauthenticated

--- a/scripts/setup-gcp.sh
+++ b/scripts/setup-gcp.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# GCP Cloud Run 배포를 위한 초기 설정 스크립트
+# 사용법: GCP_PROJECT_ID=<프로젝트ID> GITHUB_REPO=<owner/repo> bash scripts/setup-gcp.sh
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?GCP_PROJECT_ID 환경변수를 설정하세요}"
+: "${GITHUB_REPO:?GITHUB_REPO 환경변수를 설정하세요 (예: fantazzk/web-fe)}"
+
+REGION="asia-northeast3"
+SA_NAME="github-deploy"
+SA_EMAIL="${SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+POOL_NAME="github-pool"
+PROVIDER_NAME="github-provider"
+
+echo "=== 1. 필요한 API 활성화 ==="
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  iamcredentials.googleapis.com \
+  --project="$GCP_PROJECT_ID"
+
+echo "=== 2. Artifact Registry 저장소 생성 ==="
+gcloud artifacts repositories create web-fe \
+  --repository-format=docker \
+  --location="$REGION" \
+  --description="fantazzk frontend images" \
+  --project="$GCP_PROJECT_ID" \
+  2>/dev/null || echo "  (이미 존재)"
+
+echo "=== 3. 서비스 계정 생성 ==="
+gcloud iam service-accounts create "$SA_NAME" \
+  --display-name="GitHub Actions Deploy" \
+  --project="$GCP_PROJECT_ID" \
+  2>/dev/null || echo "  (이미 존재)"
+
+echo "=== 4. 서비스 계정에 권한 부여 ==="
+for ROLE in roles/run.admin roles/artifactregistry.writer roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$GCP_PROJECT_ID" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="$ROLE" \
+    --quiet
+done
+
+echo "=== 5. Workload Identity Federation 설정 ==="
+gcloud iam workload-identity-pools create "$POOL_NAME" \
+  --location="global" \
+  --project="$GCP_PROJECT_ID" \
+  2>/dev/null || echo "  (이미 존재)"
+
+gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_NAME" \
+  --location="global" \
+  --workload-identity-pool="$POOL_NAME" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='${GITHUB_REPO}'" \
+  --project="$GCP_PROJECT_ID" \
+  2>/dev/null || echo "  (이미 존재)"
+
+gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')/locations/global/workloadIdentityPools/${POOL_NAME}/attribute.repository/${GITHUB_REPO}" \
+  --project="$GCP_PROJECT_ID" \
+  --quiet
+
+echo ""
+echo "=== 설정 완료 ==="
+echo ""
+echo "GitHub Secrets에 다음 값을 등록하세요:"
+echo ""
+echo "  GCP_PROJECT_ID: ${GCP_PROJECT_ID}"
+echo ""
+PROJECT_NUMBER=$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')
+echo "  WIF_PROVIDER: projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_NAME}/providers/${PROVIDER_NAME}"
+echo ""
+echo "  WIF_SERVICE_ACCOUNT: ${SA_EMAIL}"
+echo ""


### PR DESCRIPTION
## 변경 사항

- GitHub Actions 워크플로우를 ghcr.io → GCP Artifact Registry + Cloud Run 배포로 전환
- 환경별 Cloud Run 서비스 분리 (dev → `web-fe-dev`, main → `web-fe`)
- Workload Identity Federation 기반 키 없는 인증 구성
- `min-instances=0` + `cpu-boost` 적용 (콜드 스타트 완화, 비용 최소화)
- GCP 초기 설정 자동화 스크립트 추가 (`scripts/setup-gcp.sh`)

## 미완료 (TODO)

- [ ] GCP 프로젝트 생성 후 `scripts/setup-gcp.sh` 실행
- [ ] GitHub Secrets 등록 (`GCP_PROJECT_ID`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`)

## 테스트

- [ ] `bun run check` 통과 (기존 에러 외 신규 에러 없음)
- [ ] GCP 설정 완료 후 dev push 시 Cloud Run 자동 배포 확인
- [ ] Docker 이미지 로컬 빌드 및 실행 확인

closes #50