### PR TITLE
수정(배포): Dockerfile bun install 플래그 호환성 수정 (#50)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 FROM oven/bun:1-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production=false
+RUN bun install --frozen-lockfile
 
 # --- prod-deps ---
 FROM oven/bun:1-alpine AS prod-deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production=true
 
 # --- build ---
 FROM oven/bun:1-alpine AS build


### PR DESCRIPTION
## 변경 사항

- bun 최신 버전에서 `--production=false` 플래그 미지원으로 Docker 빌드 실패 수정
- deps 스테이지: `--production=false` 제거 (기본값이 devDependencies 포함)
- prod-deps 스테이지: `--production` → `--production=true` 명시적 변경

## 테스트

- [ ] GitHub Actions Docker 빌드 성공 확인
- [ ] Cloud Run 배포 성공 확인

closes #50