### PR TITLE
수정(배포): Docker install 시 prepare 스크립트 무시 (#57)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 FROM oven/bun:1-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
 
 # --- prod-deps ---
 FROM oven/bun:1-alpine AS prod-deps
 WORKDIR /app
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile --production
+RUN bun install --frozen-lockfile --production --ignore-scripts
 
 # --- build ---
 FROM oven/bun:1-alpine AS build


### PR DESCRIPTION
## 변경 사항

- 양쪽 install 스테이지에 `--ignore-scripts` 추가
- production install에서 husky(devDep) 못 찾아 exit code 127로 빌드 실패하던 문제 해결

## 테스트

- [ ] GitHub Actions Docker 빌드 성공 확인
- [ ] Cloud Run 배포 성공 확인

closes #57