### PR TITLE
정리: Vercel 배포 관련 설정 전체 제거 (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,27 @@
 | 항목            | 기술                 |
 | --------------- | -------------------- |
 | Framework       | SvelteKit (Svelte 5) |
-| Package Manager | pnpm                 |
+| Package Manager | bun                  |
 | Styling         | Tailwind CSS v4      |
-| Deploy          | Vercel               |
+| Deploy          | GCP Cloud Run        |
 | Language        | TypeScript (strict)  |
 
 ## 시작하기
 
 ```bash
-pnpm install
-pnpm dev
+bun install
+bun run dev
 ```
 
 ## 스크립트
 
 ```bash
-pnpm dev        # 개발 서버
-pnpm build      # 프로덕션 빌드
-pnpm preview    # 빌드 미리보기
-pnpm check      # 타입 검사
-pnpm lint       # 린트
-pnpm format     # 코드 포맷
+bun run dev        # 개발 서버
+bun run build      # 프로덕션 빌드
+bun run preview    # 빌드 미리보기
+bun run check      # 타입 검사
+bun run lint       # 린트
+bun run format     # 코드 포맷
 ```
 
 ## 주요 기능
@@ -42,13 +42,11 @@ pnpm format     # 코드 포맷
 
 ## 페이지 경로
 
-배포 URL: https://fantazzk-rho.vercel.app/
-
-| 경로                                             | 설명                  |
-| ------------------------------------------------ | --------------------- |
-| https://fantazzk-rho.vercel.app/                 | 홈 (랜딩 페이지)      |
-| https://fantazzk-rho.vercel.app/templates/create | 템플릿 생성           |
-| https://fantazzk-rho.vercel.app/lobby/[id]       | 대기실 (방 입장/관리) |
-| https://fantazzk-rho.vercel.app/auction/[id]     | 경매 진행 화면        |
-| https://fantazzk-rho.vercel.app/draft/[id]       | 드래프트 진행 화면    |
-| https://fantazzk-rho.vercel.app/result/[id]      | 결과 화면             |
+| 경로                | 설명                  |
+| ------------------- | --------------------- |
+| `/`                 | 홈 (랜딩 페이지)      |
+| `/templates/create` | 템플릿 생성           |
+| `/lobby/[id]`       | 대기실 (방 입장/관리) |
+| `/auction/[id]`     | 경매 진행 화면        |
+| `/draft/[id]`       | 드래프트 진행 화면    |
+| `/result/[id]`      | 결과 화면             |

--- a/docs/bun-migration.md
+++ b/docs/bun-migration.md
@@ -81,17 +81,6 @@ Bun은 Node.js API를 대부분 지원하지만 100% 호환은 아니다. 주요
 - **네이티브 애드온** (`.node` 파일)은 지원하지 않는 경우가 있음
 - 이 프로젝트에서는 네이티브 애드온을 사용하지 않으므로 문제없음
 
-### Vercel 배포
-
-이 프로젝트는 `@sveltejs/adapter-vercel`을 사용한다. Vercel 빌드 환경에서는 bun이 기본 설치되어 있으므로 별도 설정 없이 동작한다. 필요 시 `vercel.json`에서 빌드 명령을 지정할 수 있다:
-
-```json
-{
-	"buildCommand": "bun run build",
-	"installCommand": "bun install"
-}
-```
-
 ### husky / lint-staged
 
 `bun install` 실행 시 `prepare` 스크립트(`husky`)가 정상 실행된다. `lint-staged`도 bun 환경에서 동일하게 동작한다.


### PR DESCRIPTION
## 변경 사항

- docs/bun-migration.md에서 Vercel 배포 섹션 제거
- README.md 배포를 GCP Cloud Run으로, 패키지 매니저를 bun으로 갱신
- 페이지 경로에서 Vercel URL 제거하고 상대 경로로 변경

## 테스트

- [ ] 문서 내용 확인

closes #59