### PR TITLE
기능(auction): 유찰 선수 재경매 로직 구현 (#53)

### DIFF
--- a/src/lib/domain/rule-engine/__tests__/auction-driver.test.ts
+++ b/src/lib/domain/rule-engine/__tests__/auction-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { Auction } from '$lib/domain/rule-engine/auction.ts';
-import type { AuctionConfig } from '$lib/domain/rule-engine/types.ts';
+import { Auction } from '../auction.ts';
+import type { AuctionConfig } from '../types.ts';
 import { processTimerExpiry, processBid } from '../auction-driver.ts';
 
 function createConfig(): AuctionConfig {
@@ -43,17 +43,24 @@ describe('processTimerExpiry', () => {
 		expect(next.currentPlayer?.name).toBe('선수B');
 	});
 
-	it('입찰이 없으면 유찰 후 다음 선수로 진행한다', () => {
+	it('입찰이 없으면 유찰 후 다음 선수로 진행하고 유찰 선수는 마지막에 재배치된다', () => {
 		const auction = Auction.create(createConfig()); // 입찰 없음
 		const next = processTimerExpiry(auction);
 		expect(next.phase).toBe('BIDDING');
 		expect(next.currentPlayer?.name).toBe('선수B');
+		expect(next.remainingPool.at(-1)?.name).toBe('선수A');
 	});
 
-	it('마지막 선수이면 COMPLETED로 전환한다', () => {
+	it('모든 선수가 낙찰되면 COMPLETED로 전환한다', () => {
 		let auction = Auction.create(createConfig());
+		// 선수A 낙찰
+		auction = auction.placeBid('team-1', 10);
 		auction = processTimerExpiry(auction);
+		// 선수B 낙찰
+		auction = auction.placeBid('team-2', 10);
 		auction = processTimerExpiry(auction);
+		// 선수C 낙찰
+		auction = auction.placeBid('team-1', 10);
 		auction = processTimerExpiry(auction);
 		expect(auction.isCompleted).toBe(true);
 	});

--- a/src/lib/domain/rule-engine/__tests__/auction.test.ts
+++ b/src/lib/domain/rule-engine/__tests__/auction.test.ts
@@ -127,18 +127,40 @@ describe('다음 선수 진행', () => {
 });
 
 describe('유찰', () => {
-	it('markUnsold()하면 UNSOLD가 되고 선수는 버려진다', () => {
+	it('markUnsold()하면 UNSOLD가 되고 유찰 선수는 remainingPool 끝에 재삽입된다', () => {
 		const auction = Auction.create(createConfig());
 		const unsold = auction.markUnsold();
 		expect(unsold.phase).toBe('UNSOLD');
 		expect(unsold.currentPlayer).toBeNull();
 		expect(unsold.soldPlayers).toHaveLength(0);
+		expect(unsold.remainingPool.at(-1)?.name).toBe('선수A');
 	});
 
 	it('유찰 후 startNext()로 다음 선수가 올라온다', () => {
 		const next = Auction.create(createConfig()).markUnsold().startNext();
 		expect(next.phase).toBe('BIDDING');
 		expect(next.currentPlayer?.name).toBe('선수B');
+	});
+
+	it('유찰된 선수는 나중에 다시 경매에 올라온다', () => {
+		const config = createConfig({
+			playerPool: [
+				{ name: '선수A', position: 'TOP' },
+				{ name: '선수B', position: 'MID' }
+			]
+		});
+		// 선수A 유찰 → 선수B 낙찰 → 선수A 재경매
+		let auction = Auction.create(config);
+		auction = auction.markUnsold().startNext(); // 선수A 유찰, 선수B로 진행
+		expect(auction.currentPlayer?.name).toBe('선수B');
+
+		auction = auction.placeBid('team-1', 10).settle().startNext(); // 선수B 낙찰
+		expect(auction.currentPlayer?.name).toBe('선수A'); // 선수A 재경매
+		expect(auction.phase).toBe('BIDDING');
+
+		// 선수A 낙찰 → 경매 완료
+		auction = auction.placeBid('team-2', 10).settle().startNext();
+		expect(auction.isCompleted).toBe(true);
 	});
 });
 

--- a/src/lib/domain/rule-engine/auction-driver.ts
+++ b/src/lib/domain/rule-engine/auction-driver.ts
@@ -1,5 +1,5 @@
-import { Auction } from '$lib/domain/rule-engine/auction';
-import { AuctionError } from '$lib/domain/rule-engine/errors';
+import { Auction } from './auction.ts';
+import { AuctionError } from './errors.ts';
 
 interface BidResultType {
 	readonly auction: Auction;

--- a/src/lib/domain/rule-engine/auction.ts
+++ b/src/lib/domain/rule-engine/auction.ts
@@ -138,7 +138,8 @@ export class Auction {
 			...this.toState(),
 			phase: 'UNSOLD',
 			currentPlayer: null,
-			currentBid: null
+			currentBid: null,
+			remainingPool: [...this.remainingPool, this.currentPlayer!]
 		});
 	}
 


### PR DESCRIPTION
## 변경 사항

- 유찰된 선수를 remainingPool 끝에 재삽입하여 재경매 기회 부여
- 모든 선수가 낙찰될 때까지 경매가 종료되지 않도록 변경
- auction-driver.ts import를 상대경로로 수정하여 bun test 호환성 확보

## 미완료 (TODO)

- 없음

## 테스트

- [x] `bun test` 27개 전체 통과 (auction + auction-driver)
- [x] 유찰 → remainingPool 재삽입 검증
- [x] 유찰 → 재경매 → 낙찰 전체 흐름 검증
- [x] processTimerExpiry 유찰 시 재배치 검증

closes #53