### PR TITLE
설정(api): OpenAPI spec 동기화

### DIFF
--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -15,9 +15,12 @@ export interface ApiError {
 
 // ─── Template API ───
 
+export type GameType = 'LEAGUE_OF_LEGENDS' | 'OVERWATCH_2';
+
 export interface TemplateResponse {
 	id: string;
 	name: string;
+	gameType?: GameType;
 	mode: 'AUCTION' | 'DRAFT';
 	teamCount: number;
 	teamSize: number;
@@ -32,23 +35,47 @@ export interface TemplateResponse {
 
 export interface TemplatePlayerResponse {
 	name: string;
-	displayOrder: number;
 	position?: string;
+	displayOrder: number;
+}
+
+export interface PlayerRequest {
+	name: string;
+	position: string;
 }
 
 export interface CreateTemplateRequest {
 	name: string;
+	gameType: GameType;
 	mode: 'AUCTION' | 'DRAFT';
 	teamCount: number;
 	teamSize: number;
+	pickBanTime?: number;
 	budget?: number;
+	minBidUnit?: number;
+	positionLimit?: number;
 	draftOrderStrategy?: 'SNAKE' | 'FIXED';
-	playerNames: string[];
+	players: PlayerRequest[];
 }
 
 // ─── Room API ───
 
 export type RoomStatus = 'WAITING' | 'IN_PROGRESS' | 'FINISHED';
+
+export interface AuctionTargetResponse {
+	name: string;
+	position: string;
+}
+
+export interface DraftOrderSlotResponse {
+	draftPosition: number;
+	leaderId: string;
+	nickname: string;
+}
+
+export interface DraftOrderPreviewResponse {
+	slots: DraftOrderSlotResponse[];
+}
 
 export interface RoomMemberResponse {
 	teamLeaderId: string;
@@ -58,6 +85,7 @@ export interface RoomMemberResponse {
 
 export interface RoomPlayerResponse {
 	name: string;
+	position?: string;
 	displayOrder: number;
 	status: string;
 }
@@ -67,6 +95,11 @@ export interface RoomProgressResponse {
 	currentRound: number;
 	currentLeaderId: string;
 	currentRoundLeaderIds: string[];
+	currentAuctionRoundEndsAt?: string;
+	currentAuctionTarget?: AuctionTargetResponse;
+	highestBidAmount?: number;
+	leadingLeaderId?: string;
+	bidCount?: number;
 }
 
 export interface JoinableRoomResponse {
@@ -83,11 +116,13 @@ export interface RoomResponse {
 	status: RoomStatus;
 	mode?: string;
 	teamCount?: number;
-	startReadiness?: string;
-	teamLeaders: TeamLeaderResponse[];
 	teamSize?: number;
 	budget?: number;
+	minBidUnit?: number;
 	draftOrderStrategy?: string;
+	startReadiness?: string;
+	draftOrderPreview?: DraftOrderPreviewResponse;
+	teamLeaders: TeamLeaderResponse[];
 	players?: RoomPlayerResponse[];
 	members?: RoomMemberResponse[];
 	progress?: RoomProgressResponse;
@@ -123,6 +158,16 @@ export interface TeamLeaderSessionResponse {
 	role: string;
 	actionToken: string;
 }
+
+export interface PickDraftRequest {
+	playerName: string;
+}
+
+export interface PlaceBidRequest {
+	amount: number;
+}
+
+// ─── Front-only (not in OpenAPI spec) ───
 
 export interface BidRequest {
 	teamLeaderId: string;

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -7,7 +7,10 @@ import type {
 	RoomMemberResponse,
 	RoomPlayerResponse,
 	RoomProgressResponse,
-	JoinableRoomResponse
+	JoinableRoomResponse,
+	AuctionTargetResponse,
+	DraftOrderPreviewResponse,
+	DraftOrderSlotResponse
 } from '$lib/types/api';
 
 // ─── 응답 래퍼 ───
@@ -30,6 +33,7 @@ export function createTemplateResponse(overrides?: Partial<TemplateResponse>): T
 	return {
 		id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
 		name: '스트리머 랭킹전 시즌 2',
+		gameType: 'LEAGUE_OF_LEGENDS',
 		mode: 'AUCTION',
 		teamCount: 8,
 		teamSize: 5,
@@ -158,8 +162,46 @@ export function createRoomPlayerResponse(
 ): RoomPlayerResponse {
 	return {
 		name: 'KIIN',
+		position: 'TOP',
 		displayOrder: 0,
 		status: 'AVAILABLE',
+		...overrides
+	};
+}
+
+export function createAuctionTargetResponse(
+	overrides?: Partial<AuctionTargetResponse>
+): AuctionTargetResponse {
+	return {
+		name: 'KIIN',
+		position: 'TOP',
+		...overrides
+	};
+}
+
+export function createDraftOrderSlotResponse(
+	overrides?: Partial<DraftOrderSlotResponse>
+): DraftOrderSlotResponse {
+	return {
+		draftPosition: 1,
+		leaderId: 'tl-1',
+		nickname: 'DragonSlayer',
+		...overrides
+	};
+}
+
+export function createDraftOrderPreviewResponse(
+	overrides?: Partial<DraftOrderPreviewResponse>
+): DraftOrderPreviewResponse {
+	return {
+		slots: [
+			createDraftOrderSlotResponse({
+				draftPosition: 1,
+				leaderId: 'tl-1',
+				nickname: 'DragonSlayer'
+			}),
+			createDraftOrderSlotResponse({ draftPosition: 2, leaderId: 'tl-2', nickname: 'NightHawk_KR' })
+		],
 		...overrides
 	};
 }
@@ -227,6 +269,7 @@ export function createRoomResponse(overrides?: Partial<RoomResponse>): RoomRespo
 		teamCount: 8,
 		teamSize: 5,
 		budget: 1000,
+		minBidUnit: 5,
 		draftOrderStrategy: 'SNAKE',
 		teamLeaders: createTeamLeaders(2, 1000),
 		players: [

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -79,6 +79,21 @@ export const handlers = [
 		return HttpResponse.json(success(createRoomResponse({ code })));
 	}),
 
+	http.post(`${BASE_URL}/api/v1/rooms/:code/draft-picks`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
+
+	http.post(`${BASE_URL}/api/v1/rooms/:code/bids`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
+
+	http.post(`${BASE_URL}/api/v1/rooms/:code/auction/progress`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
+
 	// ─── Solo API ───
 
 	http.get(`${BASE_URL}/api/v1/solo/auction/:templateId`, ({ params }) => {


### PR DESCRIPTION
## sync-api-spec

### 머지된 OpenAPI PR
- #52 — chore(api): sync OpenAPI spec

### 타입 변경 (src/lib/types/api.ts)
- 추가: `GameType`, `AuctionTargetResponse`, `DraftOrderSlotResponse`, `DraftOrderPreviewResponse`, `PlayerRequest`, `PickDraftRequest`, `PlaceBidRequest`
- 수정: `TemplateResponse` (`gameType` 필드 추가)
- 수정: `CreateTemplateRequest` (`gameType` 필수 필드 추가, `pickBanTime`/`minBidUnit`/`positionLimit` 추가, `playerNames: string[]` → `players: PlayerRequest[]`)
- 수정: `RoomPlayerResponse` (`position` 필드 추가)
- 수정: `RoomProgressResponse` (경매 관련 필드 추가: `currentAuctionRoundEndsAt`, `currentAuctionTarget`, `highestBidAmount`, `leadingLeaderId`, `bidCount`)
- 수정: `RoomResponse` (`minBidUnit`, `draftOrderPreview` 필드 추가)

### 핸들러 변경 (src/mocks/handlers.ts)
- 추가: `POST /api/v1/rooms/:code/draft-picks`
- 추가: `POST /api/v1/rooms/:code/bids`
- 추가: `POST /api/v1/rooms/:code/auction/progress`

### 팩토리 변경 (src/mocks/factories.ts)
- 추가: `createAuctionTargetResponse()`
- 추가: `createDraftOrderSlotResponse()`
- 추가: `createDraftOrderPreviewResponse()`
- 수정: `createTemplateResponse()` (`gameType` 기본값 추가)
- 수정: `createRoomPlayerResponse()` (`position` 기본값 추가)
- 수정: `createRoomResponse()` (`minBidUnit` 기본값 추가)