### PR TITLE
기능(#41): 템플릿 생성 POST API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# API Base URL
+# API Base URL (실제 배포 URL은 팀 내부 문서 참고)
 PUBLIC_API_URL=
 
 # Supabase

--- a/src/lib/domain/template/__tests__/mapper.test.ts
+++ b/src/lib/domain/template/__tests__/mapper.test.ts
@@ -1,0 +1,73 @@
+import { toCreateTemplateRequest } from '../mapper.ts';
+import type { TemplateInputType } from '../validate.ts';
+
+const baseInput: TemplateInputType = {
+	name: '2026 자낳대 롤 시즌1',
+	gameType: 'LEAGUE_OF_LEGENDS',
+	mode: 'AUCTION',
+	pickBanTime: 30,
+	players: [
+		{ name: 'Faker', position: 'MID', tier: 'S+' },
+		{ name: 'Zeus', position: 'TOP', tier: 'S' }
+	],
+	captainsNeeded: 2,
+	totalPoints: 1000,
+	minBid: 10
+};
+
+describe('toCreateTemplateRequest', () => {
+	it('AUCTION 모드는 budget, minBidUnit을 포함하고 draftOrderStrategy를 생략한다', () => {
+		const req = toCreateTemplateRequest(baseInput);
+		expect(req.mode).toBe('AUCTION');
+		expect(req.budget).toBe(1000);
+		expect(req.minBidUnit).toBe(10);
+		expect(req.draftOrderStrategy).toBeUndefined();
+	});
+
+	it('DRAFT 모드는 draftOrderStrategy를 포함하고 budget/minBidUnit을 생략한다', () => {
+		const { totalPoints: _t, minBid: _m, ...draftInput } = baseInput;
+		const req = toCreateTemplateRequest({
+			...draftInput,
+			mode: 'DRAFT',
+			draftMode: 'SNAKE'
+		});
+		expect(req.mode).toBe('DRAFT');
+		expect(req.draftOrderStrategy).toBe('SNAKE');
+		expect(req.budget).toBeUndefined();
+		expect(req.minBidUnit).toBeUndefined();
+	});
+
+	it('SEQUENTIAL 드래프트는 FIXED로 매핑된다', () => {
+		const req = toCreateTemplateRequest({
+			...baseInput,
+			mode: 'DRAFT',
+			draftMode: 'SEQUENTIAL'
+		});
+		expect(req.draftOrderStrategy).toBe('FIXED');
+	});
+
+	it('captainsNeeded는 teamCount로 매핑된다', () => {
+		const req = toCreateTemplateRequest({ ...baseInput, captainsNeeded: 5 });
+		expect(req.teamCount).toBe(5);
+	});
+
+	it('players에서 tier는 제외된다', () => {
+		const req = toCreateTemplateRequest(baseInput);
+		for (const p of req.players) {
+			expect('tier' in p).toBe(false);
+		}
+		expect(req.players).toEqual([
+			{ name: 'Faker', position: 'MID' },
+			{ name: 'Zeus', position: 'TOP' }
+		]);
+	});
+
+	it('VALORANT, BATTLEGROUNDS gameType도 그대로 전달된다', () => {
+		expect(toCreateTemplateRequest({ ...baseInput, gameType: 'VALORANT' }).gameType).toBe(
+			'VALORANT'
+		);
+		expect(toCreateTemplateRequest({ ...baseInput, gameType: 'BATTLEGROUNDS' }).gameType).toBe(
+			'BATTLEGROUNDS'
+		);
+	});
+});

--- a/src/lib/domain/template/__tests__/validate.test.ts
+++ b/src/lib/domain/template/__tests__/validate.test.ts
@@ -1,0 +1,22 @@
+import { validateTemplateInput } from '../validate.ts';
+import type { TemplateInputType } from '../validate.ts';
+
+const validInput: TemplateInputType = {
+	name: '2026 자낳대 롤 시즌1',
+	gameType: 'LEAGUE_OF_LEGENDS',
+	mode: 'AUCTION',
+	pickBanTime: 30,
+	players: [
+		{ name: 'Faker', position: 'MID', tier: 'S+' },
+		{ name: 'Zeus', position: 'TOP', tier: 'S' }
+	],
+	captainsNeeded: 2,
+	totalPoints: 1000,
+	minBid: 10
+};
+
+describe('validateTemplateInput', () => {
+	it('정상 입력이면 null을 반환한다', () => {
+		expect(validateTemplateInput(validInput)).toBeNull();
+	});
+});

--- a/src/lib/domain/template/__tests__/validate.test.ts
+++ b/src/lib/domain/template/__tests__/validate.test.ts
@@ -19,4 +19,117 @@ describe('validateTemplateInput', () => {
 	it('정상 입력이면 null을 반환한다', () => {
 		expect(validateTemplateInput(validInput)).toBeNull();
 	});
+
+	it('name이 빈 문자열이면 NAME_REQUIRED', () => {
+		expect(validateTemplateInput({ ...validInput, name: '' })).toBe('NAME_REQUIRED');
+	});
+
+	it('name이 whitespace만 있으면 NAME_REQUIRED', () => {
+		expect(validateTemplateInput({ ...validInput, name: '   ' })).toBe('NAME_REQUIRED');
+	});
+
+	it('pickBanTime이 0이면 PICK_BAN_TIME_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, pickBanTime: 0 })).toBe('PICK_BAN_TIME_INVALID');
+	});
+
+	it('pickBanTime이 음수면 PICK_BAN_TIME_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, pickBanTime: -5 })).toBe('PICK_BAN_TIME_INVALID');
+	});
+
+	it('players가 비어있으면 PLAYERS_TOO_FEW', () => {
+		expect(validateTemplateInput({ ...validInput, players: [] })).toBe('PLAYERS_TOO_FEW');
+	});
+
+	it('players가 1명이면 PLAYERS_TOO_FEW', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				players: [{ name: 'A', position: 'MID', tier: 'S' }]
+			})
+		).toBe('PLAYERS_TOO_FEW');
+	});
+
+	it('선수 중 이름이 빈 값이면 PLAYER_NAME_REQUIRED', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				players: [
+					{ name: 'Faker', position: 'MID', tier: 'S+' },
+					{ name: '', position: 'TOP', tier: 'A' }
+				]
+			})
+		).toBe('PLAYER_NAME_REQUIRED');
+	});
+
+	it('역할 있는 종목에서 position이 빈 값이면 PLAYER_POSITION_REQUIRED', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				players: [
+					{ name: 'Faker', position: 'MID', tier: 'S+' },
+					{ name: 'Zeus', position: '', tier: 'A' }
+				]
+			})
+		).toBe('PLAYER_POSITION_REQUIRED');
+	});
+
+	it('배틀그라운드는 position이 빈 값이어도 통과한다', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				gameType: 'BATTLEGROUNDS',
+				players: [
+					{ name: 'A', position: '', tier: 'S' },
+					{ name: 'B', position: '', tier: 'A' }
+				]
+			})
+		).toBeNull();
+	});
+
+	it('captainsNeeded가 1이면 CAPTAINS_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, captainsNeeded: 1 })).toBe('CAPTAINS_INVALID');
+	});
+
+	it('captainsNeeded가 0이면 CAPTAINS_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, captainsNeeded: 0 })).toBe('CAPTAINS_INVALID');
+	});
+
+	it('선수 수가 captainsNeeded보다 적으면 PLAYERS_LESS_THAN_CAPTAINS', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				captainsNeeded: 3,
+				players: [
+					{ name: 'A', position: 'MID', tier: 'S' },
+					{ name: 'B', position: 'TOP', tier: 'A' }
+				]
+			})
+		).toBe('PLAYERS_LESS_THAN_CAPTAINS');
+	});
+
+	it('AUCTION 모드에서 totalPoints가 0이면 AUCTION_BUDGET_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, totalPoints: 0 })).toBe('AUCTION_BUDGET_INVALID');
+	});
+
+	it('AUCTION 모드에서 minBid가 0이면 AUCTION_MIN_BID_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, minBid: 0 })).toBe('AUCTION_MIN_BID_INVALID');
+	});
+
+	it('AUCTION 모드에서 minBid가 totalPoints보다 크면 AUCTION_MIN_BID_INVALID', () => {
+		expect(validateTemplateInput({ ...validInput, totalPoints: 100, minBid: 200 })).toBe(
+			'AUCTION_MIN_BID_INVALID'
+		);
+	});
+
+	it('DRAFT 모드에서는 경매 필드가 없어도 통과한다', () => {
+		expect(
+			validateTemplateInput({
+				...validInput,
+				mode: 'DRAFT',
+				draftMode: 'SNAKE',
+				totalPoints: undefined,
+				minBid: undefined
+			})
+		).toBeNull();
+	});
 });

--- a/src/lib/domain/template/__tests__/validate.test.ts
+++ b/src/lib/domain/template/__tests__/validate.test.ts
@@ -122,13 +122,12 @@ describe('validateTemplateInput', () => {
 	});
 
 	it('DRAFT 모드에서는 경매 필드가 없어도 통과한다', () => {
+		const { totalPoints: _t, minBid: _m, ...draftInput } = validInput;
 		expect(
 			validateTemplateInput({
-				...validInput,
+				...draftInput,
 				mode: 'DRAFT',
-				draftMode: 'SNAKE',
-				totalPoints: undefined,
-				minBid: undefined
+				draftMode: 'SNAKE'
 			})
 		).toBeNull();
 	});

--- a/src/lib/domain/template/index.ts
+++ b/src/lib/domain/template/index.ts
@@ -13,3 +13,7 @@ export type {
 	PlayerParams,
 	TemplateParams
 } from './types.ts';
+export { validateTemplateInput } from './validate.ts';
+export type { TemplateInputType, TemplateValidationErrorType } from './validate.ts';
+export { toCreateTemplateRequest } from './mapper.ts';
+export type { CreateTemplateRequestType, TemplateResponseType } from './mapper.ts';

--- a/src/lib/domain/template/mapper.ts
+++ b/src/lib/domain/template/mapper.ts
@@ -1,0 +1,48 @@
+import type { GameType, TemplateModeType } from './types.ts';
+import type { TemplateInputType } from './validate.ts';
+
+// TODO: 백엔드 OpenAPI 스펙 확장 후 변경
+// - gameType: VALORANT/BATTLEGROUNDS 포함 4종으로 서버 enum 확장 예정
+// - PlayerRequest에 tier 필드 추가 예정
+export interface CreateTemplateRequestType {
+	name: string;
+	gameType: GameType;
+	mode: TemplateModeType;
+	teamCount: number;
+	pickBanTime: number;
+	budget?: number;
+	minBidUnit?: number;
+	draftOrderStrategy?: 'SNAKE' | 'FIXED';
+	players: { name: string; position: string }[];
+}
+
+export interface TemplateResponseType {
+	id: string;
+	name: string;
+	gameType: string;
+	mode: TemplateModeType;
+}
+
+export function toCreateTemplateRequest(data: TemplateInputType): CreateTemplateRequestType {
+	const base: CreateTemplateRequestType = {
+		name: data.name,
+		gameType: data.gameType,
+		mode: data.mode,
+		teamCount: data.captainsNeeded,
+		pickBanTime: data.pickBanTime,
+		// TODO: 백엔드 PlayerRequest에 tier 필드 추가되면 여기에 tier 포함
+		players: data.players.map((p) => ({ name: p.name, position: p.position }))
+	};
+
+	if (data.mode === 'AUCTION') {
+		const result: CreateTemplateRequestType = { ...base };
+		if (data.totalPoints !== undefined) result.budget = data.totalPoints;
+		if (data.minBid !== undefined) result.minBidUnit = data.minBid;
+		return result;
+	}
+
+	return {
+		...base,
+		draftOrderStrategy: data.draftMode === 'SEQUENTIAL' ? 'FIXED' : 'SNAKE'
+	};
+}

--- a/src/lib/domain/template/validate.ts
+++ b/src/lib/domain/template/validate.ts
@@ -1,0 +1,47 @@
+import type { GameType, TemplateModeType, DraftModeType, TierType } from './types.ts';
+import { POSITIONS_BY_GAME } from './types.ts';
+
+export type TemplateValidationErrorType =
+	| 'NAME_REQUIRED'
+	| 'PICK_BAN_TIME_INVALID'
+	| 'PLAYERS_TOO_FEW'
+	| 'PLAYER_NAME_REQUIRED'
+	| 'PLAYER_POSITION_REQUIRED'
+	| 'CAPTAINS_INVALID'
+	| 'PLAYERS_LESS_THAN_CAPTAINS'
+	| 'AUCTION_BUDGET_INVALID'
+	| 'AUCTION_MIN_BID_INVALID';
+
+export interface TemplateInputType {
+	name: string;
+	gameType: GameType;
+	mode: TemplateModeType;
+	pickBanTime: number;
+	players: readonly { name: string; position: string; tier?: TierType }[];
+	captainsNeeded: number;
+	totalPoints?: number;
+	minBid?: number;
+	draftMode?: DraftModeType;
+}
+
+export function validateTemplateInput(
+	data: TemplateInputType
+): TemplateValidationErrorType | null {
+	if (!data.name.trim()) return 'NAME_REQUIRED';
+	if (data.pickBanTime <= 0) return 'PICK_BAN_TIME_INVALID';
+	if (data.players.length < 2) return 'PLAYERS_TOO_FEW';
+	if (data.players.some((p) => !p.name.trim())) return 'PLAYER_NAME_REQUIRED';
+	const positions = POSITIONS_BY_GAME[data.gameType];
+	if (positions.length > 0 && data.players.some((p) => !p.position)) {
+		return 'PLAYER_POSITION_REQUIRED';
+	}
+	if (data.captainsNeeded < 2) return 'CAPTAINS_INVALID';
+	if (data.players.length < data.captainsNeeded) return 'PLAYERS_LESS_THAN_CAPTAINS';
+	if (data.mode === 'AUCTION') {
+		if ((data.totalPoints ?? 0) <= 0) return 'AUCTION_BUDGET_INVALID';
+		const minBid = data.minBid ?? 0;
+		const total = data.totalPoints ?? 0;
+		if (minBid <= 0 || minBid > total) return 'AUCTION_MIN_BID_INVALID';
+	}
+	return null;
+}

--- a/src/lib/utils/api-client.ts
+++ b/src/lib/utils/api-client.ts
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/public';
 import type { ApiResponse } from '$lib/types/api';
 
 export class ApiClientError extends Error {
@@ -13,7 +14,7 @@ export class ApiClientError extends Error {
 }
 
 function getBaseUrl(): string {
-	return import.meta.env['PUBLIC_API_URL'] ?? '';
+	return env.PUBLIC_API_URL ?? '';
 }
 
 function unwrap<T>(body: ApiResponse<T>, status: number): T {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,7 +4,6 @@ import {
 	createTemplateListResponse,
 	createTemplateDetailResponse,
 	createDraftTemplateDetailResponse,
-	createTemplateResponse,
 	createRoomResponse,
 	createRoomSessionResponse,
 	createJoinableRoomListResponse
@@ -22,13 +21,6 @@ export const handlers = [
 	http.get(`${BASE_URL}/api/v1/templates/:id`, ({ params }) => {
 		const id = params['id'] as string;
 		return HttpResponse.json(success(createTemplateDetailResponse({ id })));
-	}),
-
-	http.post(`${BASE_URL}/api/v1/templates`, async ({ request }) => {
-		const body = (await request.json()) as { name: string };
-		return HttpResponse.json(success(createTemplateResponse({ name: body.name })), {
-			status: 201
-		});
 	}),
 
 	// ─── Room API ───

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -3,7 +3,13 @@
 	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
 	import { Template } from '$lib/domain/template';
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
-	import { POSITIONS_BY_GAME } from '$lib/domain/template';
+	import {
+		POSITIONS_BY_GAME,
+		validateTemplateInput,
+		toCreateTemplateRequest
+	} from '$lib/domain/template';
+	import type { TemplateResponseType } from '$lib/domain/template';
+	import { apiPost } from '$lib/utils/api-client';
 
 	// --- State ---
 	let name = $state('');
@@ -19,15 +25,6 @@
 	let draftInfoRef = $state<HTMLElement | null>(null);
 	let activeStep = $state<number | null>(null);
 	let stepRefs = $state<(HTMLElement | null)[]>([null, null, null, null]);
-
-	function handleSoloPlay(): void {
-		const templateId = crypto.randomUUID();
-		if (mode === 'DRAFT') {
-			goto(`/draft/${templateId}`);
-		} else {
-			goto(`/auction/${templateId}`);
-		}
-	}
 
 	// --- 선수 관련 ---
 	const TIERS: TierType[] = ['S+', 'S', 'A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D'];
@@ -55,6 +52,46 @@
 			captainsNeeded
 		})
 	);
+
+	// --- API 연동 ---
+	let isCreating = $state(false);
+
+	let validationError = $derived(
+		validateTemplateInput({
+			name,
+			gameType,
+			mode,
+			pickBanTime,
+			players,
+			captainsNeeded,
+			...(mode === 'AUCTION' ? { totalPoints, minBid } : {}),
+			...(mode === 'DRAFT' ? { draftMode: draftType } : {})
+		})
+	);
+	let canSubmit = $derived(validationError === null);
+
+	async function handleCreateRoom(): Promise<void> {
+		if (!canSubmit || isCreating) return;
+		isCreating = true;
+		try {
+			const req = toCreateTemplateRequest({
+				name,
+				gameType,
+				mode,
+				pickBanTime,
+				players,
+				captainsNeeded,
+				...(mode === 'AUCTION' ? { totalPoints, minBid } : {}),
+				...(mode === 'DRAFT' ? { draftMode: draftType } : {})
+			});
+			const res = await apiPost<TemplateResponseType>(fetch, '/api/v1/templates', req);
+			await goto(mode === 'DRAFT' ? `/draft/${res.id}` : `/auction/${res.id}`);
+		} catch (e) {
+			alert(e instanceof Error ? e.message : '템플릿 생성 실패');
+		} finally {
+			isCreating = false;
+		}
+	}
 
 	// --- 옵션 상수 ---
 	const GAME_OPTIONS: { value: GameType; label: string }[] = [
@@ -539,8 +576,15 @@
 
 				<!-- Bottom Bar -->
 				<div class="flex items-center justify-end gap-3 border-t border-gray-700 px-14 py-4">
-					<Button variant="SECONDARY" size="MD" onclick={handleSoloPlay}>혼자 하기</Button>
-					<Button variant="PRIMARY" size="MD">방 만들기</Button>
+					<Button variant="SECONDARY" size="MD" disabled>혼자 하기</Button>
+					<Button
+						variant="PRIMARY"
+						size="MD"
+						onclick={handleCreateRoom}
+						disabled={!canSubmit || isCreating}
+					>
+						{isCreating ? '생성 중...' : '방 만들기'}
+					</Button>
 				</div>
 			</main>
 


### PR DESCRIPTION
## 변경 사항

- `POST /api/v1/templates` 실서버 연동 (#41 scope 확장)
- 프론트 폼 데이터 → OpenAPI `CreateTemplateRequest` 매핑
  - `captainsNeeded` → `teamCount`, `totalPoints` → `budget`, `minBid` → `minBidUnit`
  - `draftMode: SEQUENTIAL` → `draftOrderStrategy: FIXED`
  - `players[].tier` 제외 (백엔드 스펙 확장 예정, TODO 주석)
- `validateTemplateInput` 순수 도메인 함수 추가 (9개 에러 코드)
- "방 만들기" 클릭 시 POST 호출, 성공 시 mode별 `/auction/[id]`·`/draft/[id]` 이동
- "혼자 하기" 버튼 disabled (후속 이슈로 분리)
- MSW `POST /api/v1/templates` 핸들러 제거
- `api-client`: `import.meta.env` → `$env/dynamic/public` 교체 (dev 환경 주입 문제 해결)

## 미완료 (TODO)

- [ ] 백엔드 CORS allowed origins에 localhost:5173 및 web-fe-dev Cloud Run 도메인 추가 필요 (현재 403 차단)
- [ ] 백엔드 OpenAPI 스펙 확장 후 `gameType` 4종 / `PlayerRequest.tier` 재반영

## 테스트

- [x] `bun run check` — 신규 에러 0개 (기존 코드 에러 10건은 본 PR 무관)
- [x] `bun test` — 102 pass (신규 validate 17 + mapper 6)
- [x] `bun run lint` — 신규 이슈 0개
- [ ] 수동 QA — 백엔드 CORS 설정 후 진행 예정