### PR TITLE
기능(sandbox): #64 혼자하기 방 모드 추가

### DIFF
--- a/src/lib/domain/sandbox/__tests__/sandbox-board.test.ts
+++ b/src/lib/domain/sandbox/__tests__/sandbox-board.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'bun:test';
+import { SandboxBoard } from '../sandbox-board.ts';
+import { SandboxError } from '../errors.ts';
+import type { SandboxPlayerType } from '../types.ts';
+
+const PLAYERS: SandboxPlayerType[] = [
+	{ id: 'p1', name: '감스트', position: 'TOP', tier: 'S' },
+	{ id: 'p2', name: '따효니', position: 'MID', tier: 'A' },
+	{ id: 'p3', name: '침착맨', position: 'ADC', tier: 'S+' },
+	{ id: 'p4', name: '우왁굳', position: 'SUPPORT', tier: 'A+' }
+];
+
+describe('SandboxBoard', () => {
+	describe('create', () => {
+		it('감독 수만큼 빈 로스터가 생성된다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 3,
+				players: PLAYERS
+			});
+			expect(board.captains).toHaveLength(3);
+			expect(board.captains[0]!.name).toBe('감독 1');
+			expect(board.captains[1]!.name).toBe('감독 2');
+			expect(board.captains[2]!.name).toBe('감독 3');
+			expect(board.pool).toHaveLength(4);
+			for (const captain of board.captains) {
+				expect(board.rosters[captain.id]).toEqual([]);
+			}
+		});
+
+		it('선수풀에 모든 선수가 포함된다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			expect(board.pool.map((p) => p.id)).toEqual(['p1', 'p2', 'p3', 'p4']);
+		});
+	});
+
+	describe('assign', () => {
+		it('선수를 pool에서 감독 로스터로 이동한다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const captainId = board.captains[0]!.id;
+			const next = board.assign('p1', captainId);
+			expect(next.pool).toHaveLength(3);
+			expect(next.pool.find((p) => p.id === 'p1')).toBeUndefined();
+			expect(next.rosters[captainId]).toHaveLength(1);
+			expect(next.rosters[captainId]![0]!.id).toBe('p1');
+		});
+
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const captainId = board.captains[0]!.id;
+			board.assign('p1', captainId);
+			expect(board.pool).toHaveLength(4);
+			expect(board.rosters[captainId]).toHaveLength(0);
+		});
+
+		it('pool에 없는 선수를 assign하면 PLAYER_NOT_IN_POOL 에러', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const captainId = board.captains[0]!.id;
+			expect(() => board.assign('nonexistent', captainId)).toThrow(SandboxError);
+			try {
+				board.assign('nonexistent', captainId);
+			} catch (e) {
+				expect((e as SandboxError).code).toBe('PLAYER_NOT_IN_POOL');
+			}
+		});
+
+		it('존재하지 않는 감독에게 assign하면 CAPTAIN_NOT_FOUND 에러', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			expect(() => board.assign('p1', 'no-captain')).toThrow(SandboxError);
+			try {
+				board.assign('p1', 'no-captain');
+			} catch (e) {
+				expect((e as SandboxError).code).toBe('CAPTAIN_NOT_FOUND');
+			}
+		});
+	});
+
+	describe('unassign', () => {
+		it('감독 로스터에서 pool로 복귀시킨다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const captainId = board.captains[0]!.id;
+			const assigned = board.assign('p1', captainId);
+			const unassigned = assigned.unassign('p1');
+			expect(unassigned.pool).toHaveLength(4);
+			expect(unassigned.pool.find((p) => p.id === 'p1')).toBeDefined();
+			expect(unassigned.rosters[captainId]).toHaveLength(0);
+		});
+
+		it('어느 로스터에도 없는 선수는 PLAYER_NOT_IN_ROSTER 에러', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			expect(() => board.unassign('p1')).toThrow(SandboxError);
+			try {
+				board.unassign('p1');
+			} catch (e) {
+				expect((e as SandboxError).code).toBe('PLAYER_NOT_IN_ROSTER');
+			}
+		});
+	});
+
+	describe('move', () => {
+		it('한 감독 로스터에서 다른 감독 로스터로 이동한다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap1 = board.captains[0]!.id;
+			const cap2 = board.captains[1]!.id;
+			const assigned = board.assign('p1', cap1);
+			const moved = assigned.move('p1', cap2);
+			expect(moved.rosters[cap1]).toHaveLength(0);
+			expect(moved.rosters[cap2]).toHaveLength(1);
+			expect(moved.rosters[cap2]![0]!.id).toBe('p1');
+			expect(moved.pool).toHaveLength(3);
+		});
+
+		it('같은 감독으로 move하면 변경 없이 새 인스턴스 반환', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap1 = board.captains[0]!.id;
+			const assigned = board.assign('p1', cap1);
+			const same = assigned.move('p1', cap1);
+			expect(same).not.toBe(assigned);
+			expect(same.rosters[cap1]).toHaveLength(1);
+		});
+
+		it('로스터에 없는 선수를 move하면 PLAYER_NOT_IN_ROSTER 에러', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap2 = board.captains[1]!.id;
+			expect(() => board.move('p1', cap2)).toThrow(SandboxError);
+		});
+
+		it('존재하지 않는 감독으로 move하면 CAPTAIN_NOT_FOUND 에러', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap1 = board.captains[0]!.id;
+			const assigned = board.assign('p1', cap1);
+			expect(() => assigned.move('p1', 'no-captain')).toThrow(SandboxError);
+		});
+	});
+
+	describe('toResult', () => {
+		it('감독별 로스터를 SandboxResultTeamType 배열로 변환한다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap1 = board.captains[0]!.id;
+			const cap2 = board.captains[1]!.id;
+			const final = board.assign('p1', cap1).assign('p2', cap2);
+			const result = final.toResult();
+			expect(result).toHaveLength(2);
+			expect(result[0]!.captain).toBe('감독 1');
+			expect(result[0]!.players).toHaveLength(1);
+			expect(result[0]!.players[0]).toEqual({ name: '감스트', position: 'TOP', tier: 'S' });
+			expect(result[1]!.captain).toBe('감독 2');
+			expect(result[1]!.players).toHaveLength(1);
+			expect(result[1]!.players[0]).toEqual({ name: '따효니', position: 'MID', tier: 'A' });
+		});
+
+		it('빈 로스터도 빈 players 배열로 포함된다', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const result = board.toResult();
+			expect(result).toHaveLength(2);
+			expect(result[0]!.players).toEqual([]);
+			expect(result[1]!.players).toEqual([]);
+		});
+	});
+});

--- a/src/lib/domain/sandbox/__tests__/sandbox-board.test.ts
+++ b/src/lib/domain/sandbox/__tests__/sandbox-board.test.ts
@@ -110,6 +110,19 @@ describe('SandboxBoard', () => {
 			expect(unassigned.rosters[captainId]).toHaveLength(0);
 		});
 
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const captainId = board.captains[0]!.id;
+			const assigned = board.assign('p1', captainId);
+			assigned.unassign('p1');
+			expect(assigned.rosters[captainId]).toHaveLength(1);
+			expect(assigned.pool).toHaveLength(3);
+		});
+
 		it('어느 로스터에도 없는 선수는 PLAYER_NOT_IN_ROSTER 에러', () => {
 			const board = SandboxBoard.create({
 				templateId: 'tpl-1',
@@ -153,6 +166,20 @@ describe('SandboxBoard', () => {
 			const same = assigned.move('p1', cap1);
 			expect(same).not.toBe(assigned);
 			expect(same.rosters[cap1]).toHaveLength(1);
+		});
+
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = SandboxBoard.create({
+				templateId: 'tpl-1',
+				captainsCount: 2,
+				players: PLAYERS
+			});
+			const cap1 = board.captains[0]!.id;
+			const cap2 = board.captains[1]!.id;
+			const assigned = board.assign('p1', cap1);
+			assigned.move('p1', cap2);
+			expect(assigned.rosters[cap1]).toHaveLength(1);
+			expect(assigned.rosters[cap2]).toHaveLength(0);
 		});
 
 		it('로스터에 없는 선수를 move하면 PLAYER_NOT_IN_ROSTER 에러', () => {

--- a/src/lib/domain/sandbox/errors.ts
+++ b/src/lib/domain/sandbox/errors.ts
@@ -1,0 +1,15 @@
+export type SandboxErrorCode =
+	| 'PLAYER_NOT_IN_POOL'
+	| 'PLAYER_NOT_IN_ROSTER'
+	| 'CAPTAIN_NOT_FOUND'
+	| 'DUPLICATE_ASSIGNMENT';
+
+export class SandboxError extends Error {
+	readonly code: SandboxErrorCode;
+
+	constructor(code: SandboxErrorCode, message?: string) {
+		super(message ?? code);
+		this.code = code;
+		this.name = 'SandboxError';
+	}
+}

--- a/src/lib/domain/sandbox/index.ts
+++ b/src/lib/domain/sandbox/index.ts
@@ -1,0 +1,10 @@
+export { SandboxBoard } from './sandbox-board.ts';
+export { SandboxError } from './errors.ts';
+export type { SandboxErrorCode } from './errors.ts';
+export type {
+	SandboxPlayerType,
+	SandboxCaptainType,
+	SandboxBoardParamsType,
+	SandboxResultPlayerType,
+	SandboxResultTeamType
+} from './types.ts';

--- a/src/lib/domain/sandbox/sandbox-board.ts
+++ b/src/lib/domain/sandbox/sandbox-board.ts
@@ -1,0 +1,131 @@
+import type {
+	SandboxBoardParamsType,
+	SandboxCaptainType,
+	SandboxPlayerType,
+	SandboxResultTeamType
+} from './types.ts';
+import { SandboxError } from './errors.ts';
+
+export class SandboxBoard {
+	readonly templateId: string;
+	readonly captains: readonly SandboxCaptainType[];
+	readonly pool: readonly SandboxPlayerType[];
+	readonly rosters: Readonly<Record<string, readonly SandboxPlayerType[]>>;
+
+	constructor(params: SandboxBoardParamsType) {
+		this.templateId = params.templateId;
+		this.captains = params.captains;
+		this.pool = params.pool;
+		this.rosters = params.rosters;
+	}
+
+	static create(params: {
+		templateId: string;
+		captainsCount: number;
+		players: readonly SandboxPlayerType[];
+	}): SandboxBoard {
+		const captains: SandboxCaptainType[] = Array.from({ length: params.captainsCount }, (_, i) => ({
+			id: `captain-${i + 1}`,
+			name: `감독 ${i + 1}`
+		}));
+		const rosters: Record<string, readonly SandboxPlayerType[]> = {};
+		for (const captain of captains) {
+			rosters[captain.id] = [];
+		}
+		return new SandboxBoard({
+			templateId: params.templateId,
+			captains,
+			pool: [...params.players],
+			rosters
+		});
+	}
+
+	assign(playerId: string, toCaptainId: string): SandboxBoard {
+		if (!this.captains.some((c) => c.id === toCaptainId)) {
+			throw new SandboxError('CAPTAIN_NOT_FOUND');
+		}
+		const playerIndex = this.pool.findIndex((p) => p.id === playerId);
+		if (playerIndex === -1) {
+			throw new SandboxError('PLAYER_NOT_IN_POOL');
+		}
+		const player = this.pool[playerIndex]!;
+		const nextPool = [...this.pool.slice(0, playerIndex), ...this.pool.slice(playerIndex + 1)];
+		const nextRosters = { ...this.rosters };
+		nextRosters[toCaptainId] = [...(nextRosters[toCaptainId] ?? []), player];
+		return new SandboxBoard({
+			templateId: this.templateId,
+			captains: this.captains,
+			pool: nextPool,
+			rosters: nextRosters
+		});
+	}
+
+	unassign(playerId: string): SandboxBoard {
+		let found: SandboxPlayerType | null = null;
+		let fromCaptainId: string | null = null;
+		for (const captain of this.captains) {
+			const roster = this.rosters[captain.id] ?? [];
+			const player = roster.find((p) => p.id === playerId);
+			if (player) {
+				found = player;
+				fromCaptainId = captain.id;
+				break;
+			}
+		}
+		if (!found || !fromCaptainId) {
+			throw new SandboxError('PLAYER_NOT_IN_ROSTER');
+		}
+		const nextRosters = { ...this.rosters };
+		nextRosters[fromCaptainId] = (nextRosters[fromCaptainId] ?? []).filter(
+			(p) => p.id !== playerId
+		);
+		return new SandboxBoard({
+			templateId: this.templateId,
+			captains: this.captains,
+			pool: [...this.pool, found],
+			rosters: nextRosters
+		});
+	}
+
+	move(playerId: string, toCaptainId: string): SandboxBoard {
+		if (!this.captains.some((c) => c.id === toCaptainId)) {
+			throw new SandboxError('CAPTAIN_NOT_FOUND');
+		}
+		let found: SandboxPlayerType | null = null;
+		let fromCaptainId: string | null = null;
+		for (const captain of this.captains) {
+			const roster = this.rosters[captain.id] ?? [];
+			const player = roster.find((p) => p.id === playerId);
+			if (player) {
+				found = player;
+				fromCaptainId = captain.id;
+				break;
+			}
+		}
+		if (!found || !fromCaptainId) {
+			throw new SandboxError('PLAYER_NOT_IN_ROSTER');
+		}
+		const nextRosters = { ...this.rosters };
+		nextRosters[fromCaptainId] = (nextRosters[fromCaptainId] ?? []).filter(
+			(p) => p.id !== playerId
+		);
+		nextRosters[toCaptainId] = [...(nextRosters[toCaptainId] ?? []), found];
+		return new SandboxBoard({
+			templateId: this.templateId,
+			captains: this.captains,
+			pool: this.pool,
+			rosters: nextRosters
+		});
+	}
+
+	toResult(): SandboxResultTeamType[] {
+		return this.captains.map((captain) => ({
+			captain: captain.name,
+			players: (this.rosters[captain.id] ?? []).map((p) => ({
+				name: p.name,
+				position: p.position as string | null,
+				tier: p.tier
+			}))
+		}));
+	}
+}

--- a/src/lib/domain/sandbox/types.ts
+++ b/src/lib/domain/sandbox/types.ts
@@ -1,0 +1,32 @@
+import type { GamePositionType } from '$lib/domain/template';
+
+export interface SandboxPlayerType {
+	readonly id: string;
+	readonly name: string;
+	readonly position: GamePositionType | null;
+	readonly tier: string;
+}
+
+export interface SandboxCaptainType {
+	readonly id: string;
+	readonly name: string;
+}
+
+export interface SandboxBoardParamsType {
+	readonly templateId: string;
+	readonly captains: readonly SandboxCaptainType[];
+	readonly pool: readonly SandboxPlayerType[];
+	readonly rosters: Readonly<Record<string, readonly SandboxPlayerType[]>>;
+}
+
+/** 결과 스냅샷용 (toResult 반환 타입) */
+export interface SandboxResultPlayerType {
+	name: string;
+	position: string | null;
+	tier: string;
+}
+
+export interface SandboxResultTeamType {
+	captain: string;
+	players: SandboxResultPlayerType[];
+}

--- a/src/lib/domain/session/types.ts
+++ b/src/lib/domain/session/types.ts
@@ -1,8 +1,8 @@
 /** 세션 생명주기: 대기 → 진행 중 → 완료 */
 export type SessionStatus = 'WAITING' | 'IN_PROGRESS' | 'COMPLETED';
 
-/** 게임 진행 방식: 경매(포인트 입찰) 또는 드래프트(순차 픽) */
-export type SessionMode = 'AUCTION' | 'DRAFT';
+/** 게임 진행 방식: 경매(포인트 입찰), 드래프트(순차 픽), 샌드박스(자유 배치) */
+export type SessionMode = 'AUCTION' | 'DRAFT' | 'SANDBOX';
 
 /** 참가자 유형: 실제 유저 또는 솔로 모드 AI */
 export type ParticipantType = 'HUMAN' | 'AI';

--- a/src/lib/features/result/types.ts
+++ b/src/lib/features/result/types.ts
@@ -1,23 +1,5 @@
-import type { SandboxResultPlayerType, SandboxResultTeamType } from '$lib/domain/sandbox';
-
-// 경매 결과 (기존 ResultPlayer / ResultTeam rename)
-export interface AuctionResultPlayerType {
-	name: string;
-	position: string;
-	price: string;
-}
-
-export interface AuctionResultTeamType {
-	captain: string;
-	players: AuctionResultPlayerType[];
-	total: string;
-}
-
-// 도메인에서 re-export
-export type { SandboxResultPlayerType, SandboxResultTeamType };
-
-// 판별 유니언 (모드별 결과)
-export type ResultSnapshotType =
-	| { mode: 'AUCTION'; teams: AuctionResultTeamType[] }
-	| { mode: 'DRAFT'; teams: AuctionResultTeamType[] } // TODO: DraftResultTeamType 분리 (별도 이슈)
-	| { mode: 'SANDBOX'; teams: SandboxResultTeamType[] };
+export type {
+	AuctionResultPlayerType,
+	AuctionResultTeamType,
+	ResultSnapshotType
+} from '$lib/types/snapshot';

--- a/src/lib/features/result/types.ts
+++ b/src/lib/features/result/types.ts
@@ -1,11 +1,23 @@
-export interface ResultPlayer {
+import type { SandboxResultPlayerType, SandboxResultTeamType } from '$lib/domain/sandbox';
+
+// 경매 결과 (기존 ResultPlayer / ResultTeam rename)
+export interface AuctionResultPlayerType {
 	name: string;
 	position: string;
 	price: string;
 }
 
-export interface ResultTeam {
+export interface AuctionResultTeamType {
 	captain: string;
-	players: ResultPlayer[];
+	players: AuctionResultPlayerType[];
 	total: string;
 }
+
+// 도메인에서 re-export
+export type { SandboxResultPlayerType, SandboxResultTeamType };
+
+// 판별 유니언 (모드별 결과)
+export type ResultSnapshotType =
+	| { mode: 'AUCTION'; teams: AuctionResultTeamType[] }
+	| { mode: 'DRAFT'; teams: AuctionResultTeamType[] } // TODO: DraftResultTeamType 분리 (별도 이슈)
+	| { mode: 'SANDBOX'; teams: SandboxResultTeamType[] };

--- a/src/lib/features/sandbox/components/CaptainRoster.svelte
+++ b/src/lib/features/sandbox/components/CaptainRoster.svelte
@@ -40,8 +40,8 @@
 	ondragenter={handleDragEnter}
 	ondragleave={handleDragLeave}
 	ondrop={handleDrop}
-	role="list"
-	aria-label="{captain.name} 로스터"
+	role="group"
+	aria-label="{captain.name} 감독"
 >
 	<!-- Header -->
 	<div class="flex items-center justify-between border-b border-gray-700 px-4 py-3">
@@ -52,11 +52,15 @@
 	</div>
 
 	<!-- Player list -->
-	<div class="flex flex-1 flex-col gap-1 overflow-y-auto p-2">
+	<div
+		class="flex flex-1 flex-col gap-1 overflow-y-auto p-2"
+		role="list"
+		aria-label="{captain.name} 로스터"
+	>
 		{#each players as player (player.id)}
 			<PlayerCard {player} />
 		{:else}
-			<div class="flex flex-1 items-center justify-center p-4">
+			<div class="flex flex-1 items-center justify-center p-4" role="listitem">
 				<span class="font-mono text-xs text-dim">선수를 드래그하세요</span>
 			</div>
 		{/each}

--- a/src/lib/features/sandbox/components/CaptainRoster.svelte
+++ b/src/lib/features/sandbox/components/CaptainRoster.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import type { SandboxCaptainType, SandboxPlayerType } from '$lib/domain/sandbox';
+	import PlayerCard from './PlayerCard.svelte';
+
+	interface Props {
+		captain: SandboxCaptainType;
+		players: readonly SandboxPlayerType[];
+		onDrop: (playerId: string, captainId: string) => void;
+	}
+
+	let { captain, players, onDrop }: Props = $props();
+	let dragOverCount = $state(0);
+
+	function handleDragOver(e: DragEvent): void {
+		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+	}
+
+	function handleDragEnter(e: DragEvent): void {
+		e.preventDefault();
+		dragOverCount++;
+	}
+
+	function handleDragLeave(): void {
+		dragOverCount--;
+	}
+
+	function handleDrop(e: DragEvent): void {
+		e.preventDefault();
+		dragOverCount = 0;
+		const playerId = e.dataTransfer?.getData('application/x-player-id');
+		if (playerId) onDrop(playerId, captain.id);
+	}
+</script>
+
+<div
+	class="flex min-w-[200px] flex-col border border-gray-700
+		{dragOverCount > 0 ? 'border-accent bg-accent/5' : 'bg-bg-elevated'}"
+	ondragover={handleDragOver}
+	ondragenter={handleDragEnter}
+	ondragleave={handleDragLeave}
+	ondrop={handleDrop}
+	role="list"
+	aria-label="{captain.name} 로스터"
+>
+	<!-- Header -->
+	<div class="flex items-center justify-between border-b border-gray-700 px-4 py-3">
+		<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
+			{captain.name.toUpperCase()}
+		</span>
+		<span class="font-mono text-xs text-muted">{players.length}명</span>
+	</div>
+
+	<!-- Player list -->
+	<div class="flex flex-1 flex-col gap-1 overflow-y-auto p-2">
+		{#each players as player (player.id)}
+			<PlayerCard {player} />
+		{:else}
+			<div class="flex flex-1 items-center justify-center p-4">
+				<span class="font-mono text-xs text-dim">선수를 드래그하세요</span>
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/features/sandbox/components/PlayerCard.svelte
+++ b/src/lib/features/sandbox/components/PlayerCard.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { SandboxPlayerType } from '$lib/domain/sandbox';
+
+	interface Props {
+		player: SandboxPlayerType;
+		draggable?: boolean;
+	}
+
+	let { player, draggable = true }: Props = $props();
+
+	function handleDragStart(e: DragEvent): void {
+		if (!e.dataTransfer) return;
+		e.dataTransfer.setData('application/x-player-id', player.id);
+		e.dataTransfer.effectAllowed = 'move';
+	}
+</script>
+
+<div
+	class="flex items-center gap-3 border border-gray-700 bg-bg-primary px-3 py-2 font-mono text-sm transition-colors
+		{draggable ? 'cursor-grab hover:border-accent active:cursor-grabbing' : ''}"
+	draggable={draggable ? 'true' : 'false'}
+	ondragstart={handleDragStart}
+	role="listitem"
+>
+	<span class="w-8 text-center text-xs font-semibold text-accent">{player.tier}</span>
+	<span class="flex-1 text-gray-50">{player.name}</span>
+	{#if player.position}
+		<span class="text-xs text-muted">{player.position}</span>
+	{/if}
+</div>

--- a/src/lib/features/sandbox/components/PlayerPool.svelte
+++ b/src/lib/features/sandbox/components/PlayerPool.svelte
@@ -51,6 +51,8 @@
 	ondragenter={handleDragEnter}
 	ondragleave={handleDragLeave}
 	ondrop={handleDrop}
+	role="region"
+	aria-label="선수풀 — 선수를 여기로 드래그하여 배정 해제"
 >
 	<!-- Header + Position Filter -->
 	<div class="flex items-center gap-4">

--- a/src/lib/features/sandbox/components/PlayerPool.svelte
+++ b/src/lib/features/sandbox/components/PlayerPool.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import type { SandboxPlayerType } from '$lib/domain/sandbox';
+	import type { GameType } from '$lib/domain/template';
+	import { POSITIONS_BY_GAME } from '$lib/domain/template';
+	import PlayerCard from './PlayerCard.svelte';
+
+	interface Props {
+		pool: readonly SandboxPlayerType[];
+		gameType: GameType;
+		positionFilter: string;
+		onFilterChange: (position: string) => void;
+		onDropToPool: (playerId: string) => void;
+	}
+
+	let { pool, gameType, positionFilter, onFilterChange, onDropToPool }: Props = $props();
+
+	let positions = $derived(POSITIONS_BY_GAME[gameType]);
+	let hasPositions = $derived(positions.length > 0);
+	let filteredPool = $derived(
+		positionFilter === 'ALL' ? pool : pool.filter((p) => p.position === positionFilter)
+	);
+
+	let dragOverCount = $state(0);
+
+	function handleDragOver(e: DragEvent): void {
+		e.preventDefault();
+		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+	}
+
+	function handleDragEnter(e: DragEvent): void {
+		e.preventDefault();
+		dragOverCount++;
+	}
+
+	function handleDragLeave(): void {
+		dragOverCount--;
+	}
+
+	function handleDrop(e: DragEvent): void {
+		e.preventDefault();
+		dragOverCount = 0;
+		const playerId = e.dataTransfer?.getData('application/x-player-id');
+		if (playerId) onDropToPool(playerId);
+	}
+</script>
+
+<div
+	class="flex flex-col gap-3 border-t border-gray-700 p-4
+		{dragOverCount > 0 ? 'bg-accent/5' : ''}"
+	ondragover={handleDragOver}
+	ondragenter={handleDragEnter}
+	ondragleave={handleDragLeave}
+	ondrop={handleDrop}
+>
+	<!-- Header + Position Filter -->
+	<div class="flex items-center gap-4">
+		<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">
+			선수풀 ({pool.length}명)
+		</span>
+		{#if hasPositions}
+			<div class="flex gap-1">
+				<button
+					class="px-2.5 py-1 font-mono text-xs transition-colors
+						{positionFilter === 'ALL'
+						? 'bg-accent font-semibold text-bg-primary'
+						: 'text-muted hover:text-gray-50'}"
+					onclick={() => onFilterChange('ALL')}
+				>
+					전체
+				</button>
+				{#each positions as pos (pos.value)}
+					<button
+						class="px-2.5 py-1 font-mono text-xs transition-colors
+							{positionFilter === pos.value
+							? 'bg-accent font-semibold text-bg-primary'
+							: 'text-muted hover:text-gray-50'}"
+						onclick={() => onFilterChange(pos.value)}
+					>
+						{pos.label}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Player Grid -->
+	<div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+		{#each filteredPool as player (player.id)}
+			<PlayerCard {player} />
+		{:else}
+			<div class="col-span-full py-8 text-center font-mono text-xs text-dim">
+				{positionFilter === 'ALL' ? '모든 선수가 배정되었습니다' : '해당 포지션의 선수가 없습니다'}
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/features/sandbox/stores/sandbox-store.svelte.ts
+++ b/src/lib/features/sandbox/stores/sandbox-store.svelte.ts
@@ -1,0 +1,26 @@
+import { SandboxBoard } from '$lib/domain/sandbox';
+
+class SandboxStore {
+	board = $state<SandboxBoard | null>(null);
+	positionFilter = $state<string>('ALL');
+
+	init(board: SandboxBoard): void {
+		this.board = board;
+		this.positionFilter = 'ALL';
+	}
+
+	apply(next: SandboxBoard): void {
+		this.board = next;
+	}
+
+	setPositionFilter(position: string): void {
+		this.positionFilter = position;
+	}
+
+	reset(): void {
+		this.board = null;
+		this.positionFilter = 'ALL';
+	}
+}
+
+export const sandboxStore = new SandboxStore();

--- a/src/lib/features/sandbox/types.ts
+++ b/src/lib/features/sandbox/types.ts
@@ -1,9 +1,1 @@
-import type { GameType } from '$lib/domain/template';
-import type { SandboxPlayerType } from '$lib/domain/sandbox';
-
-export interface TemplateSnapshotType {
-	name: string;
-	gameType: GameType;
-	captainsCount: number;
-	players: SandboxPlayerType[];
-}
+export type { TemplateSnapshotType } from '$lib/types/snapshot';

--- a/src/lib/features/sandbox/types.ts
+++ b/src/lib/features/sandbox/types.ts
@@ -1,0 +1,9 @@
+import type { GameType } from '$lib/domain/template';
+import type { SandboxPlayerType } from '$lib/domain/sandbox';
+
+export interface TemplateSnapshotType {
+	name: string;
+	gameType: GameType;
+	captainsCount: number;
+	players: SandboxPlayerType[];
+}

--- a/src/lib/types/snapshot.ts
+++ b/src/lib/types/snapshot.ts
@@ -1,0 +1,29 @@
+import type { GameType } from '$lib/domain/template';
+import type { SandboxPlayerType, SandboxResultTeamType } from '$lib/domain/sandbox';
+
+// 템플릿 → 샌드박스 진입 시 캐시에 저장하는 스냅샷
+export interface TemplateSnapshotType {
+	name: string;
+	gameType: GameType;
+	captainsCount: number;
+	players: SandboxPlayerType[];
+}
+
+// 경매 결과
+export interface AuctionResultPlayerType {
+	name: string;
+	position: string;
+	price: string;
+}
+
+export interface AuctionResultTeamType {
+	captain: string;
+	players: AuctionResultPlayerType[];
+	total: string;
+}
+
+// 판별 유니언 (모드별 결과)
+export type ResultSnapshotType =
+	| { mode: 'AUCTION'; teams: AuctionResultTeamType[] }
+	| { mode: 'DRAFT'; teams: AuctionResultTeamType[] } // TODO: DraftResultTeamType 분리 (별도 이슈)
+	| { mode: 'SANDBOX'; teams: SandboxResultTeamType[] };

--- a/src/lib/utils/__tests__/cache.test.ts
+++ b/src/lib/utils/__tests__/cache.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import * as cache from '../cache.ts';
+
+// bun test는 브라우저 환경이 아니므로 localStorage를 인메모리로 모킹한다
+const store: Record<string, string> = {};
+const localStorage = {
+	getItem: (key: string) => store[key] ?? null,
+	setItem: (key: string, value: string) => {
+		store[key] = value;
+	},
+	removeItem: (key: string) => {
+		delete store[key];
+	},
+	clear: () => {
+		for (const key of Object.keys(store)) delete store[key];
+	}
+};
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true });
+Object.defineProperty(globalThis, 'localStorage', { value: localStorage, writable: true });
+
+describe('cache', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	describe('set/get', () => {
+		it('저장한 데이터를 조회할 수 있다', () => {
+			cache.set('key1', { name: '테스트' }, 60_000);
+			const entry = cache.get<{ name: string }>('key1');
+			expect(entry).not.toBeNull();
+			expect(entry!.data.name).toBe('테스트');
+		});
+
+		it('savedAt과 expiresAt이 기록된다', () => {
+			const before = Date.now();
+			cache.set('key1', 'data', 60_000);
+			const after = Date.now();
+			const entry = cache.get<string>('key1');
+			expect(entry!.savedAt).toBeGreaterThanOrEqual(before);
+			expect(entry!.savedAt).toBeLessThanOrEqual(after);
+			expect(entry!.expiresAt).toBeGreaterThanOrEqual(before + 60_000);
+			expect(entry!.expiresAt).toBeLessThanOrEqual(after + 60_000);
+		});
+
+		it('존재하지 않는 키는 null을 반환한다', () => {
+			expect(cache.get('nonexistent')).toBeNull();
+		});
+	});
+
+	describe('TTL 만료', () => {
+		it('만료된 엔트리는 null을 반환하고 스토리지에서 제거된다', () => {
+			cache.set('expired', 'data', -1);
+			expect(cache.get('expired')).toBeNull();
+			expect(localStorage.getItem('expired')).toBeNull();
+		});
+	});
+
+	describe('consume', () => {
+		it('데이터를 반환하고 스토리지에서 제거한다', () => {
+			cache.set('key1', 'data', 60_000);
+			const entry = cache.consume<string>('key1');
+			expect(entry!.data).toBe('data');
+			expect(cache.get<string>('key1')).toBeNull();
+		});
+
+		it('존재하지 않는 키는 null을 반환한다', () => {
+			expect(cache.consume('nonexistent')).toBeNull();
+		});
+
+		it('만료된 엔트리는 null을 반환한다', () => {
+			cache.set('expired', 'data', -1);
+			expect(cache.consume('expired')).toBeNull();
+		});
+	});
+
+	describe('remove', () => {
+		it('지정한 키를 삭제한다', () => {
+			cache.set('key1', 'data', 60_000);
+			cache.remove('key1');
+			expect(cache.get<string>('key1')).toBeNull();
+		});
+	});
+
+	describe('JSON 파싱 실패', () => {
+		it('잘못된 JSON은 null 반환 후 키를 제거한다', () => {
+			localStorage.setItem('broken', '{invalid json}');
+			expect(cache.get('broken')).toBeNull();
+			expect(localStorage.getItem('broken')).toBeNull();
+		});
+	});
+});

--- a/src/lib/utils/cache.ts
+++ b/src/lib/utils/cache.ts
@@ -1,0 +1,48 @@
+export interface CacheEntryType<T> {
+	data: T;
+	savedAt: number;
+	expiresAt: number;
+}
+
+function isBrowser(): boolean {
+	return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+}
+
+export function set<T>(key: string, data: T, ttlMs: number): void {
+	if (!isBrowser()) return;
+	const now = Date.now();
+	const entry: CacheEntryType<T> = { data, savedAt: now, expiresAt: now + ttlMs };
+	try {
+		localStorage.setItem(key, JSON.stringify(entry));
+	} catch {
+		// QuotaExceededError 등 무시
+	}
+}
+
+export function get<T>(key: string): CacheEntryType<T> | null {
+	if (!isBrowser()) return null;
+	const raw = localStorage.getItem(key);
+	if (raw === null) return null;
+	try {
+		const entry = JSON.parse(raw) as CacheEntryType<T>;
+		if (Date.now() > entry.expiresAt) {
+			localStorage.removeItem(key);
+			return null;
+		}
+		return entry;
+	} catch {
+		localStorage.removeItem(key);
+		return null;
+	}
+}
+
+export function consume<T>(key: string): CacheEntryType<T> | null {
+	const entry = get<T>(key);
+	if (entry !== null) localStorage.removeItem(key);
+	return entry;
+}
+
+export function remove(key: string): void {
+	if (!isBrowser()) return;
+	localStorage.removeItem(key);
+}

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -10,10 +10,12 @@
 	let saving = $state(false);
 	let saveMessage = $state('');
 	let snapshot = $state<ResultSnapshotType | null>(null);
+	let loaded = $state(false);
 
 	onMount(() => {
 		const entry = cache.consume<ResultSnapshotType>(`result:${$page.params.id}`);
 		if (entry) snapshot = entry.data;
+		loaded = true;
 		// TODO: 캐시 miss 시 GET /api/v1/results/:id (백엔드 미구현)
 	});
 
@@ -102,7 +104,12 @@
 	<title>결과 | Fantazzk</title>
 </svelte:head>
 
-{#if snapshot?.mode === 'SANDBOX'}
+{#if loaded && !snapshot}
+	<div class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary">
+		<p class="font-mono text-sm text-muted">결과 데이터를 찾을 수 없습니다</p>
+		<a href="/" class="font-mono text-sm text-accent hover:underline">홈으로 돌아가기</a>
+	</div>
+{:else if snapshot?.mode === 'SANDBOX'}
 	<div class="flex min-h-screen flex-col gap-8 bg-bg-primary px-14 py-12">
 		<h1 class="font-heading text-3xl font-bold text-gray-50">샌드박스 결과</h1>
 		<div class="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { toPng } from 'html-to-image';
 	import { Button, Icon } from '$lib/components';
-	import type { ResultTeam } from '$lib/features/result/types';
+	import type { AuctionResultTeamType } from '$lib/features/result/types';
 
 	let cardEl: HTMLDivElement;
 	let saving = $state(false);
@@ -34,7 +34,7 @@
 		mode: 'AUCTION' as const
 	};
 
-	const teams: ResultTeam[] = [
+	const teams: AuctionResultTeamType[] = [
 		{
 			captain: '풍월량',
 			players: [

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
 	import { toPng } from 'html-to-image';
+	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
 	import { Button, Icon } from '$lib/components';
-	import type { AuctionResultTeamType } from '$lib/features/result/types';
+	import * as cache from '$lib/utils/cache';
+	import type { AuctionResultTeamType, ResultSnapshotType } from '$lib/features/result/types';
 
 	let cardEl: HTMLDivElement;
 	let saving = $state(false);
 	let saveMessage = $state('');
+	let snapshot = $state<ResultSnapshotType | null>(null);
+
+	onMount(() => {
+		const entry = cache.consume<ResultSnapshotType>(`result:${$page.params.id}`);
+		if (entry) snapshot = entry.data;
+		// TODO: 캐시 miss 시 GET /api/v1/results/:id (백엔드 미구현)
+	});
 
 	async function saveImage() {
 		if (saving) return;
@@ -92,103 +102,131 @@
 	<title>결과 | Fantazzk</title>
 </svelte:head>
 
-<main class="flex h-screen flex-col bg-bg-primary">
-	<!-- Result Card (이미지 캡처 대상 영역) -->
-	<div bind:this={cardEl} class="flex flex-1 flex-col overflow-hidden">
-		<!-- Top Accent Bar -->
-		<div class="h-[3px] w-full bg-accent"></div>
+{#if snapshot?.mode === 'SANDBOX'}
+	<div class="flex min-h-screen flex-col gap-8 bg-bg-primary px-14 py-12">
+		<h1 class="font-heading text-3xl font-bold text-gray-50">샌드박스 결과</h1>
+		<div class="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">
+			{#each snapshot.teams as team}
+				<div class="flex flex-col gap-2 border border-gray-700 p-4">
+					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
+						{team.captain.toUpperCase()}
+					</span>
+					{#each team.players as player}
+						<div class="flex items-center gap-2 font-mono text-sm">
+							<span class="w-8 text-center text-xs font-semibold text-accent">
+								{player.tier}
+							</span>
+							<span class="flex-1 text-gray-50">{player.name}</span>
+							{#if player.position}
+								<span class="text-xs text-muted">{player.position}</span>
+							{/if}
+						</div>
+					{:else}
+						<span class="font-mono text-xs text-dim">배정된 선수 없음</span>
+					{/each}
+				</div>
+			{/each}
+		</div>
+	</div>
+{:else}
+	<main class="flex h-screen flex-col bg-bg-primary">
+		<!-- Result Card (이미지 캡처 대상 영역) -->
+		<div bind:this={cardEl} class="flex flex-1 flex-col overflow-hidden">
+			<!-- Top Accent Bar -->
+			<div class="h-[3px] w-full bg-accent"></div>
 
-		<!-- Header -->
-		<header class="flex flex-col items-center gap-2 px-8 pt-8 pb-4">
-			<h1 class="font-heading text-4xl font-bold tracking-[2px] text-accent">
-				{tournament.title}
-			</h1>
-			<p class="font-mono text-sm font-semibold tracking-wider text-muted">
-				{tournament.subtitle}
-			</p>
-			<p class="font-mono text-sm text-subtle">
-				{tournament.date}
-			</p>
-		</header>
+			<!-- Header -->
+			<header class="flex flex-col items-center gap-2 px-8 pt-8 pb-4">
+				<h1 class="font-heading text-4xl font-bold tracking-[2px] text-accent">
+					{tournament.title}
+				</h1>
+				<p class="font-mono text-sm font-semibold tracking-wider text-muted">
+					{tournament.subtitle}
+				</p>
+				<p class="font-mono text-sm text-subtle">
+					{tournament.date}
+				</p>
+			</header>
 
-		<!-- Divider -->
-		<div class="mx-8 h-px bg-accent opacity-30"></div>
+			<!-- Divider -->
+			<div class="mx-8 h-px bg-accent opacity-30"></div>
 
-		<!-- Team Cards -->
-		<section class="flex flex-1 overflow-hidden px-8 py-6">
-			<ul class="flex flex-1 list-none gap-4">
-				{#each teams as team (team.captain)}
-					<li class="flex flex-1">
-						<article class="flex flex-1 flex-col border border-gray-700">
-							<!-- Captain Header -->
-							<div class="flex flex-col items-center gap-1 bg-accent px-4 py-4">
-								<h2 class="font-heading text-xl font-bold text-bg-primary">
-									{team.captain}
-								</h2>
-								<span
-									class="font-mono text-[10px] font-semibold tracking-[2px] text-bg-primary opacity-50"
+			<!-- Team Cards -->
+			<section class="flex flex-1 overflow-hidden px-8 py-6">
+				<ul class="flex flex-1 list-none gap-4">
+					{#each teams as team (team.captain)}
+						<li class="flex flex-1">
+							<article class="flex flex-1 flex-col border border-gray-700">
+								<!-- Captain Header -->
+								<div class="flex flex-col items-center gap-1 bg-accent px-4 py-4">
+									<h2 class="font-heading text-xl font-bold text-bg-primary">
+										{team.captain}
+									</h2>
+									<span
+										class="font-mono text-[10px] font-semibold tracking-[2px] text-bg-primary opacity-50"
+									>
+										CAPTAIN
+									</span>
+								</div>
+
+								<!-- Player List -->
+								<ol class="flex flex-1 list-none flex-col gap-4 px-4 py-5">
+									{#each team.players as player, pi (player.name)}
+										<li class="flex flex-col gap-1">
+											<span class="font-mono text-base font-semibold text-gray-50">
+												{String(pi + 1).padStart(2, '0')}&nbsp;&nbsp;{player.name}
+											</span>
+											<span class="font-mono text-sm text-muted">
+												{player.position} · {player.price}
+											</span>
+										</li>
+									{/each}
+								</ol>
+
+								<!-- Total Row -->
+								<div
+									class="flex items-center justify-between border-t border-gray-700 bg-bg-elevated px-4 py-3"
 								>
-									CAPTAIN
-								</span>
-							</div>
+									<span class="font-mono text-xs font-semibold tracking-wider text-subtle">
+										TOTAL
+									</span>
+									<span class="font-mono text-base font-bold text-accent">
+										{team.total}
+									</span>
+								</div>
+							</article>
+						</li>
+					{/each}
+				</ul>
+			</section>
 
-							<!-- Player List -->
-							<ol class="flex flex-1 list-none flex-col gap-4 px-4 py-5">
-								{#each team.players as player, pi (player.name)}
-									<li class="flex flex-col gap-1">
-										<span class="font-mono text-base font-semibold text-gray-50">
-											{String(pi + 1).padStart(2, '0')}&nbsp;&nbsp;{player.name}
-										</span>
-										<span class="font-mono text-sm text-muted">
-											{player.position} · {player.price}
-										</span>
-									</li>
-								{/each}
-							</ol>
+			<!-- Footer -->
+			<footer class="flex flex-col items-center gap-1 pb-5">
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-dim"> FANTAZZK.GG </span>
+				<span class="font-mono text-[10px] tracking-wider text-subtle">
+					MOCK DRAFT & AUCTION PLATFORM
+				</span>
+			</footer>
+		</div>
 
-							<!-- Total Row -->
-							<div
-								class="flex items-center justify-between border-t border-gray-700 bg-bg-elevated px-4 py-3"
-							>
-								<span class="font-mono text-xs font-semibold tracking-wider text-subtle">
-									TOTAL
-								</span>
-								<span class="font-mono text-base font-bold text-accent">
-									{team.total}
-								</span>
-							</div>
-						</article>
-					</li>
-				{/each}
-			</ul>
-		</section>
+		<!-- Action Bar (캡처 영역 밖) -->
+		<div class="flex items-center justify-center gap-4 border-t border-gray-700 px-8 py-5">
+			<Button variant="SECONDARY" size="MD" onclick={saveImage} disabled={saving}>
+				<span class="flex items-center gap-2">
+					<Icon name="download" size={16} />
+					{saving ? '저장 중…' : '이미지 저장'}
+				</span>
+			</Button>
+			<Button variant="SECONDARY" size="MD" disabled>
+				<span class="flex items-center gap-2">
+					<Icon name="link" size={16} />
+					링크 복사
+				</span>
+			</Button>
+			<Button variant="PRIMARY" size="MD" disabled>다시 하기</Button>
+		</div>
 
-		<!-- Footer -->
-		<footer class="flex flex-col items-center gap-1 pb-5">
-			<span class="font-mono text-xs font-semibold tracking-[2px] text-dim"> FANTAZZK.GG </span>
-			<span class="font-mono text-[10px] tracking-wider text-subtle">
-				MOCK DRAFT & AUCTION PLATFORM
-			</span>
-		</footer>
-	</div>
-
-	<!-- Action Bar (캡처 영역 밖) -->
-	<div class="flex items-center justify-center gap-4 border-t border-gray-700 px-8 py-5">
-		<Button variant="SECONDARY" size="MD" onclick={saveImage} disabled={saving}>
-			<span class="flex items-center gap-2">
-				<Icon name="download" size={16} />
-				{saving ? '저장 중…' : '이미지 저장'}
-			</span>
-		</Button>
-		<Button variant="SECONDARY" size="MD" disabled>
-			<span class="flex items-center gap-2">
-				<Icon name="link" size={16} />
-				링크 복사
-			</span>
-		</Button>
-		<Button variant="PRIMARY" size="MD" disabled>다시 하기</Button>
-	</div>
-
-	<!-- 스크린리더 상태 알림 -->
-	<div aria-live="polite" class="sr-only">{saveMessage}</div>
-</main>
+		<!-- 스크린리더 상태 알림 -->
+		<div aria-live="polite" class="sr-only">{saveMessage}</div>
+	</main>
+{/if}

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -105,12 +105,12 @@
 </svelte:head>
 
 {#if loaded && !snapshot}
-	<div class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary">
+	<main class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary" role="alert">
 		<p class="font-mono text-sm text-muted">결과 데이터를 찾을 수 없습니다</p>
 		<a href="/" class="font-mono text-sm text-accent hover:underline">홈으로 돌아가기</a>
-	</div>
+	</main>
 {:else if snapshot?.mode === 'SANDBOX'}
-	<div class="flex min-h-screen flex-col gap-8 bg-bg-primary px-14 py-12">
+	<main class="flex min-h-screen flex-col gap-8 bg-bg-primary px-14 py-12">
 		<h1 class="font-heading text-3xl font-bold text-gray-50">샌드박스 결과</h1>
 		<div class="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">
 			{#each snapshot.teams as team}
@@ -118,23 +118,25 @@
 					<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
 						{team.captain.toUpperCase()}
 					</span>
-					{#each team.players as player}
-						<div class="flex items-center gap-2 font-mono text-sm">
-							<span class="w-8 text-center text-xs font-semibold text-accent">
-								{player.tier}
-							</span>
-							<span class="flex-1 text-gray-50">{player.name}</span>
-							{#if player.position}
-								<span class="text-xs text-muted">{player.position}</span>
-							{/if}
-						</div>
-					{:else}
-						<span class="font-mono text-xs text-dim">배정된 선수 없음</span>
-					{/each}
+					<ul class="flex list-none flex-col gap-1">
+						{#each team.players as player}
+							<li class="flex items-center gap-2 font-mono text-sm">
+								<span class="w-8 text-center text-xs font-semibold text-accent">
+									{player.tier}
+								</span>
+								<span class="flex-1 text-gray-50">{player.name}</span>
+								{#if player.position}
+									<span class="text-xs text-muted">{player.position}</span>
+								{/if}
+							</li>
+						{:else}
+							<li class="font-mono text-xs text-dim">배정된 선수 없음</li>
+						{/each}
+					</ul>
 				</div>
 			{/each}
 		</div>
-	</div>
+	</main>
 {:else}
 	<main class="flex h-screen flex-col bg-bg-primary">
 		<!-- Result Card (이미지 캡처 대상 영역) -->

--- a/src/routes/sandbox/[templateId]/+page.svelte
+++ b/src/routes/sandbox/[templateId]/+page.svelte
@@ -41,7 +41,8 @@
 		try {
 			const next = sandboxStore.board.assign(playerId, captainId);
 			sandboxStore.apply(next);
-		} catch {
+		} catch (e) {
+			if (!(e instanceof Error) || !('code' in e) || e.code !== 'PLAYER_NOT_IN_POOL') return;
 			try {
 				const next = sandboxStore.board.move(playerId, captainId);
 				sandboxStore.apply(next);

--- a/src/routes/sandbox/[templateId]/+page.svelte
+++ b/src/routes/sandbox/[templateId]/+page.svelte
@@ -6,8 +6,7 @@
 	import { SandboxBoard } from '$lib/domain/sandbox';
 	import * as cache from '$lib/utils/cache';
 	import { sandboxStore } from '$lib/features/sandbox/stores/sandbox-store.svelte';
-	import type { TemplateSnapshotType } from '$lib/features/sandbox/types';
-	import type { ResultSnapshotType } from '$lib/features/result/types';
+	import type { TemplateSnapshotType, ResultSnapshotType } from '$lib/types/snapshot';
 	import type { GameType } from '$lib/domain/template';
 	import CaptainRoster from '$lib/features/sandbox/components/CaptainRoster.svelte';
 	import PlayerPool from '$lib/features/sandbox/components/PlayerPool.svelte';
@@ -79,10 +78,10 @@
 </svelte:head>
 
 {#if error}
-	<div class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary">
+	<main class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary" role="alert">
 		<p class="font-mono text-sm text-muted">템플릿 정보를 찾을 수 없습니다</p>
 		<Button variant="PRIMARY" size="MD" onclick={() => goto('/')}>홈으로 돌아가기</Button>
-	</div>
+	</main>
 {:else if loaded && sandboxStore.board}
 	<div class="flex h-screen flex-col bg-bg-primary">
 		<!-- Top Bar -->
@@ -94,8 +93,10 @@
 		<!-- Captain Rosters (top) -->
 		<section
 			class="flex gap-3 overflow-x-auto border-b border-gray-700 p-4"
+			aria-labelledby="captain-roster-heading"
 			style="max-height: 45vh;"
 		>
+			<h2 id="captain-roster-heading" class="sr-only">감독 로스터</h2>
 			{#each sandboxStore.board.captains as captain (captain.id)}
 				<CaptainRoster
 					{captain}
@@ -106,7 +107,7 @@
 		</section>
 
 		<!-- Player Pool (bottom) -->
-		<section class="flex-1 overflow-y-auto">
+		<section class="flex-1 overflow-y-auto" aria-label="선수풀">
 			<PlayerPool
 				pool={sandboxStore.board.pool}
 				{gameType}
@@ -117,7 +118,11 @@
 		</section>
 	</div>
 {:else}
-	<div class="flex h-screen items-center justify-center bg-bg-primary">
+	<div
+		class="flex h-screen items-center justify-center bg-bg-primary"
+		role="status"
+		aria-live="polite"
+	>
 		<span class="font-mono text-sm text-muted">로딩 중...</span>
 	</div>
 {/if}

--- a/src/routes/sandbox/[templateId]/+page.svelte
+++ b/src/routes/sandbox/[templateId]/+page.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { Button } from '$lib/components';
+	import { SandboxBoard } from '$lib/domain/sandbox';
+	import * as cache from '$lib/utils/cache';
+	import { sandboxStore } from '$lib/features/sandbox/stores/sandbox-store.svelte';
+	import type { TemplateSnapshotType } from '$lib/features/sandbox/types';
+	import type { ResultSnapshotType } from '$lib/features/result/types';
+	import type { GameType } from '$lib/domain/template';
+	import CaptainRoster from '$lib/features/sandbox/components/CaptainRoster.svelte';
+	import PlayerPool from '$lib/features/sandbox/components/PlayerPool.svelte';
+
+	const templateId = $page.params.templateId;
+
+	let templateName = $state('');
+	let gameType = $state<GameType>('LEAGUE_OF_LEGENDS');
+	let loaded = $state(false);
+	let error = $state(false);
+
+	onMount(() => {
+		const entry = cache.get<TemplateSnapshotType>(`template:${templateId}`);
+		if (!entry) {
+			error = true;
+			return;
+		}
+		templateName = entry.data.name;
+		gameType = entry.data.gameType;
+		const board = SandboxBoard.create({
+			templateId,
+			captainsCount: entry.data.captainsCount,
+			players: entry.data.players
+		});
+		sandboxStore.init(board);
+		loaded = true;
+	});
+
+	function handleDropToRoster(playerId: string, captainId: string): void {
+		if (!sandboxStore.board) return;
+		try {
+			const next = sandboxStore.board.assign(playerId, captainId);
+			sandboxStore.apply(next);
+		} catch {
+			try {
+				const next = sandboxStore.board.move(playerId, captainId);
+				sandboxStore.apply(next);
+			} catch {
+				// 이동 불가 — 무시
+			}
+		}
+	}
+
+	function handleDropToPool(playerId: string): void {
+		if (!sandboxStore.board) return;
+		try {
+			const next = sandboxStore.board.unassign(playerId);
+			sandboxStore.apply(next);
+		} catch {
+			// pool에 이미 있는 선수 — 무시
+		}
+	}
+
+	function handleComplete(): void {
+		if (!sandboxStore.board) return;
+		const snapshot: ResultSnapshotType = {
+			mode: 'SANDBOX',
+			teams: sandboxStore.board.toResult()
+		};
+		cache.set(`result:${templateId}`, snapshot, 30 * 60 * 1000);
+		cache.remove(`template:${templateId}`);
+		goto(`/result/${templateId}`);
+	}
+</script>
+
+<svelte:head>
+	<title>{templateName || 'Sandbox'} — Fantazzk</title>
+</svelte:head>
+
+{#if error}
+	<div class="flex h-screen flex-col items-center justify-center gap-4 bg-bg-primary">
+		<p class="font-mono text-sm text-muted">템플릿 정보를 찾을 수 없습니다</p>
+		<Button variant="PRIMARY" size="MD" onclick={() => goto('/')}>홈으로 돌아가기</Button>
+	</div>
+{:else if loaded && sandboxStore.board}
+	<div class="flex h-screen flex-col bg-bg-primary">
+		<!-- Top Bar -->
+		<header class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
+			<span class="font-heading text-xl font-bold text-gray-50">{templateName}</span>
+			<Button variant="PRIMARY" size="MD" onclick={handleComplete}>완성하기</Button>
+		</header>
+
+		<!-- Captain Rosters (top) -->
+		<section
+			class="flex gap-3 overflow-x-auto border-b border-gray-700 p-4"
+			style="max-height: 45vh;"
+		>
+			{#each sandboxStore.board.captains as captain (captain.id)}
+				<CaptainRoster
+					{captain}
+					players={sandboxStore.board.rosters[captain.id] ?? []}
+					onDrop={handleDropToRoster}
+				/>
+			{/each}
+		</section>
+
+		<!-- Player Pool (bottom) -->
+		<section class="flex-1 overflow-y-auto">
+			<PlayerPool
+				pool={sandboxStore.board.pool}
+				{gameType}
+				positionFilter={sandboxStore.positionFilter}
+				onFilterChange={(pos) => sandboxStore.setPositionFilter(pos)}
+				onDropToPool={handleDropToPool}
+			/>
+		</section>
+	</div>
+{:else}
+	<div class="flex h-screen items-center justify-center bg-bg-primary">
+		<span class="font-mono text-sm text-muted">로딩 중...</span>
+	</div>
+{/if}

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -5,7 +5,7 @@
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
 	import { POSITIONS_BY_GAME } from '$lib/domain/template';
 	import * as cache from '$lib/utils/cache';
-	import type { TemplateSnapshotType } from '$lib/features/sandbox/types';
+	import type { TemplateSnapshotType } from '$lib/types/snapshot';
 
 	// --- State ---
 	let name = $state('');

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -4,6 +4,8 @@
 	import { Template } from '$lib/domain/template';
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
 	import { POSITIONS_BY_GAME } from '$lib/domain/template';
+	import * as cache from '$lib/utils/cache';
+	import type { TemplateSnapshotType } from '$lib/features/sandbox/types';
 
 	// --- State ---
 	let name = $state('');
@@ -22,11 +24,19 @@
 
 	function handleSoloPlay(): void {
 		const templateId = crypto.randomUUID();
-		if (mode === 'DRAFT') {
-			goto(`/draft/${templateId}`);
-		} else {
-			goto(`/auction/${templateId}`);
-		}
+		const snapshot: TemplateSnapshotType = {
+			name,
+			gameType,
+			captainsCount: captainsNeeded,
+			players: players.map((p) => ({
+				id: crypto.randomUUID(),
+				name: p.name,
+				position: (p.position as string) || null,
+				tier: p.tier
+			}))
+		};
+		cache.set(`template:${templateId}`, snapshot, 60 * 60 * 1000);
+		goto(`/sandbox/${templateId}`);
 	}
 
 	// --- 선수 관련 ---


### PR DESCRIPTION
## 변경 사항

- `lib/utils/cache.ts` 신규 — 제네릭 localStorage Cache (savedAt + expiresAt + TTL 자동 만료)
- `lib/domain/sandbox/` 신규 — 불변 SandboxBoard 클래스 (assign/unassign/move/toResult)
- `SessionMode` 타입에 `'SANDBOX'` 추가
- Result 타입 모드별 분리 — `AuctionResultTeamType`, `SandboxResultTeamType`, `ResultSnapshotType` 판별 유니언
- `/sandbox/[templateId]` 라우트 및 UI — 상하 레이아웃, 네이티브 HTML5 DnD, 포지션 필터
- `templates/create` "혼자 하기" 버튼 → Cache에 템플릿 저장 후 `/sandbox/[templateId]`로 이동
- `/result/[id]` 페이지 — cache.consume으로 결과 로드, SANDBOX 분기 렌더, cache miss 시 에러 상태

## 미완료 (TODO)

- [ ] 홈에 "방 만들기" 진입점 추가 (별도 이슈)
- [ ] AI/Solo 도메인·라우트·MSW 제거 (#42)
- [ ] 결과 페이지 AUCTION/DRAFT mode full 분기 렌더링
- [ ] 백엔드 결과 조회 API 연동 (`GET /api/v1/results/:id`)
- [ ] 키보드 접근성
- [ ] 모바일 터치 DnD 폴리필

## 테스트

- [x] `bun run check` 통과 (기존 bun:test/supabase 에러만 — 신규 코드 무관)
- [x] `bun run build` 성공
- [x] `bun test` 105/105 PASS (Cache 9건 + SandboxBoard 16건 + 기존 80건)
- [ ] dev 서버 수동 검증: 템플릿 생성 → 혼자 하기 → DnD → 완성 → 결과 확인

Closes #64