### PR TITLE
개선(i18n): #24 전체 UI 텍스트 한글화

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,19 +15,19 @@
 			tag: 'LOL',
 			number: '01',
 			name: '스트리머 랭킹전 시즌 2',
-			stats: [{ label: '8 TEAMS' }, { label: '842 USES' }]
+			stats: [{ label: '8팀' }, { label: '842회 사용' }]
 		},
 		{
 			tag: 'VALORANT',
 			number: '02',
 			name: '발로란트 프로 경매전',
-			stats: [{ label: '6 TEAMS' }, { label: '1.5K USES' }]
+			stats: [{ label: '6팀' }, { label: '1.5K회 사용' }]
 		},
 		{
 			tag: 'PUBG',
 			number: '03',
 			name: '배그 스쿼드 드래프트',
-			stats: [{ label: '4 TEAMS' }, { label: '2.1K USES' }]
+			stats: [{ label: '4팀' }, { label: '2.1K회 사용' }]
 		}
 	];
 
@@ -95,9 +95,7 @@
 		<!-- Hero Section -->
 		<section class="flex h-[260px] items-center gap-10 border border-gray-50 p-8">
 			<div class="flex flex-1 flex-col justify-center gap-4">
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent">
-					FEATURED TOURNAMENT
-				</span>
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-accent"> 추천 대회 </span>
 				<h1 class="font-heading text-4xl font-bold text-gray-50">Chzzk 챌린저스 시즌 3</h1>
 				<p class="font-mono text-[13px] leading-relaxed text-muted">
 					최고의 스트리머들이 펼치는 리그 오브 레전드 토너먼트.<br />
@@ -105,17 +103,15 @@
 				</p>
 				<div class="flex gap-6">
 					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						GAME: LOL
+						게임: LOL
 					</span>
+					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted"> 팀: 8 </span>
 					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						TEAMS: 8
-					</span>
-					<span class="font-mono text-[11px] font-semibold tracking-wider text-muted">
-						USED: 1.2K
+						사용: 1.2K
 					</span>
 				</div>
 				<div>
-					<Button variant="PRIMARY" size="MD">QUICK START</Button>
+					<Button variant="PRIMARY" size="MD">빠른 시작</Button>
 				</div>
 			</div>
 			<div class="h-full w-[280px] rounded-sm bg-gray-800"></div>
@@ -123,7 +119,7 @@
 
 		<!-- Popular Templates -->
 		<section class="flex flex-col gap-6">
-			<SectionHeader title="POPULAR TEMPLATES" actionText="VIEW ALL →" actionHref="/templates" />
+			<SectionHeader title="인기 템플릿" actionText="모두 보기 →" actionHref="/templates" />
 			<div class="flex gap-6">
 				{#each templates as t, i (i)}
 					<div class="flex-1">
@@ -137,7 +133,7 @@
 		<section class="flex flex-col gap-4">
 			<div class="flex w-full items-center justify-between">
 				<h2 class="font-heading text-2xl font-semibold tracking-wider text-gray-50">
-					RECENT COMMUNITY RESULTS
+					최근 커뮤니티 결과
 				</h2>
 				<Badge variant="STATUS">LIVE</Badge>
 			</div>

--- a/src/routes/lobby/[id]/+page.svelte
+++ b/src/routes/lobby/[id]/+page.svelte
@@ -103,7 +103,7 @@
 				<span
 					class="border border-accent px-4 py-2 font-mono text-sm font-semibold tracking-wider text-accent"
 				>
-					ROOM {room.code}
+					방 {room.code}
 				</span>
 			</div>
 			<div class="flex items-center gap-4">

--- a/src/routes/lobby/[id]/+page.svelte
+++ b/src/routes/lobby/[id]/+page.svelte
@@ -10,11 +10,11 @@
 	};
 
 	const settingsItems = [
-		{ label: 'MODE', value: 'AUCTION' },
-		{ label: 'TEAMS', value: '4' },
-		{ label: 'POINTS', value: '1,000 PTS' },
-		{ label: 'TIME', value: '30 SEC' },
-		{ label: 'ROSTER', value: '5 PLAYERS' }
+		{ label: '모드', value: 'AUCTION' },
+		{ label: '팀', value: '4' },
+		{ label: '포인트', value: '1,000P' },
+		{ label: '시간', value: '30초' },
+		{ label: '로스터', value: '5명' }
 	];
 
 	interface Participant {
@@ -98,7 +98,7 @@
 		<header class="flex h-[72px] items-center justify-between border-b border-gray-700 px-14">
 			<div class="flex items-center gap-6">
 				<h1 class="font-heading text-3xl font-semibold tracking-wider text-gray-50">
-					MULTIPLAYER LOBBY
+					멀티플레이어 로비
 				</h1>
 				<span
 					class="border border-accent px-4 py-2 font-mono text-sm font-semibold tracking-wider text-accent"
@@ -112,7 +112,7 @@
 					class="flex items-center gap-2 bg-accent px-6 py-2.5 font-mono text-sm font-semibold tracking-wider text-bg-primary"
 				>
 					<Icon name="link" size={14} />
-					COPY LINK
+					링크 복사
 				</button>
 				<span class="font-mono text-base font-semibold text-muted">
 					{participants.length}/{maxPlayers}
@@ -126,9 +126,7 @@
 			<div class="flex flex-1 flex-col gap-8">
 				<!-- Participants -->
 				<section>
-					<h2 class="mb-4 font-mono text-sm font-semibold tracking-[2px] text-accent">
-						PARTICIPANTS
-					</h2>
+					<h2 class="mb-4 font-mono text-sm font-semibold tracking-[2px] text-accent">참가자</h2>
 					<ul class="flex list-none flex-col gap-2">
 						{#each participants as p, i (p.nickname)}
 							<li class="flex items-center justify-between border border-gray-700 px-4 py-3">

--- a/src/routes/result/[id]/+page.svelte
+++ b/src/routes/result/[id]/+page.svelte
@@ -174,7 +174,7 @@
 									<span
 										class="font-mono text-[10px] font-semibold tracking-[2px] text-bg-primary opacity-50"
 									>
-										CAPTAIN
+										감독
 									</span>
 								</div>
 
@@ -197,7 +197,7 @@
 									class="flex items-center justify-between border-t border-gray-700 bg-bg-elevated px-4 py-3"
 								>
 									<span class="font-mono text-xs font-semibold tracking-wider text-subtle">
-										TOTAL
+										합계
 									</span>
 									<span class="font-mono text-base font-bold text-accent">
 										{team.total}


### PR DESCRIPTION
## 변경 사항

- 홈 페이지 영문 라벨/헤더 한글화 (FEATURED TOURNAMENT, POPULAR TEMPLATES, QUICK START 등)
- 로비 페이지 영문 라벨 한글화 (MULTIPLAYER LOBBY, PARTICIPANTS, COPY LINK, 설정 항목)
- 결과 페이지 CAPTAIN/TOTAL 한글화
- 브랜드명(FANTAZZK), 게임 용어(AUCTION/DRAFT), 포지션(TOP/MID 등), 상태 배지(HOST/READY/LIVE), STEP 등은 영문 유지

## 미완료 (TODO)

- 없음

## 테스트

- [x] `bun run check` 통과 (기존 에러만 존재, 한글화 관련 에러 없음)
- [x] 기존 한글 텍스트와 톤 일치 확인
- [x] 레이아웃 영향 없음 확인 (문자열 길이 유사)

closes #24