### PR TITLE
기능(sidebar): #35 사이드바 네비게이션 통합 및 Settings 모달 추가

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -12,7 +12,8 @@
 		| 'link'
 		| 'refresh-cw'
 		| 'play'
-		| 'info';
+		| 'info'
+		| 'file-check';
 
 	interface Props {
 		name: IconName;
@@ -97,5 +98,9 @@
 		<circle cx="12" cy="12" r="10" />
 		<line x1="12" y1="16" x2="12" y2="12" />
 		<line x1="12" y1="8" x2="12.01" y2="8" />
+	{:else if name === 'file-check'}
+		<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+		<path d="M14 2v4a2 2 0 0 0 2 2h4" />
+		<path d="m9 15 2 2 4-4" />
 	{/if}
 </svg>

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	type IconName =
+	export type IconName =
 		| 'layout-grid'
 		| 'file-text'
 		| 'trending-up'

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import Icon from './Icon.svelte';
+	import ThemePicker from './ThemePicker.svelte';
+
+	interface Props {
+		open: boolean;
+		onclose: () => void;
+	}
+
+	let { open = $bindable(), onclose }: Props = $props();
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) {
+			onclose();
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onclose();
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+		role="dialog"
+		aria-modal="true"
+		aria-label="설정"
+		onclick={handleBackdropClick}
+	>
+		<div class="w-[400px] border border-gray-700 bg-bg-primary p-6">
+			<!-- Header -->
+			<div class="flex items-center justify-between">
+				<h2 class="font-heading text-xl font-bold tracking-wider text-gray-50">설정</h2>
+				<button
+					type="button"
+					class="flex items-center justify-center text-muted hover:text-gray-50"
+					aria-label="닫기"
+					onclick={onclose}
+				>
+					<Icon name="close" size={18} />
+				</button>
+			</div>
+
+			<!-- Language -->
+			<div class="mt-6 flex flex-col gap-2">
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">언어</span>
+				<div
+					class="flex h-10 items-center border border-gray-700 px-4 font-mono text-sm text-subtle opacity-60"
+				>
+					한국어
+				</div>
+			</div>
+
+			<!-- Theme -->
+			<div class="mt-6 flex flex-col gap-2">
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">테마</span>
+				<ThemePicker />
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -9,6 +9,15 @@
 
 	let { open, onclose }: Props = $props();
 
+	let dialogEl: HTMLDivElement | undefined = $state();
+	let closeButtonEl: HTMLButtonElement | undefined = $state();
+
+	$effect(() => {
+		if (open && closeButtonEl) {
+			closeButtonEl.focus();
+		}
+	});
+
 	function handleBackdropClick(e: MouseEvent) {
 		if (e.target === e.currentTarget) {
 			onclose();
@@ -18,6 +27,32 @@
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			onclose();
+			return;
+		}
+
+		if (e.key === 'Tab' && dialogEl) {
+			const focusable = Array.from(
+				dialogEl.querySelectorAll<HTMLElement>(
+					'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+				)
+			).filter((el) => !el.hasAttribute('disabled'));
+
+			if (focusable.length === 0) return;
+
+			const first = focusable[0]!;
+			const last = focusable[focusable.length - 1]!;
+
+			if (e.shiftKey) {
+				if (document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				}
+			} else {
+				if (document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
+			}
 		}
 	}
 </script>
@@ -32,11 +67,12 @@
 		onclick={handleBackdropClick}
 		onkeydown={handleKeydown}
 	>
-		<div class="w-[400px] border border-gray-700 bg-bg-primary p-6">
+		<div bind:this={dialogEl} class="w-[400px] border border-gray-700 bg-bg-primary p-6">
 			<!-- Header -->
 			<div class="flex items-center justify-between">
 				<h2 class="font-heading text-xl font-bold tracking-wider text-gray-50">설정</h2>
 				<button
+					bind:this={closeButtonEl}
 					type="button"
 					class="flex items-center justify-center text-muted hover:text-gray-50"
 					aria-label="닫기"
@@ -47,8 +83,10 @@
 			</div>
 
 			<!-- Language -->
-			<div class="mt-6 flex flex-col gap-2">
-				<span class="font-mono text-xs font-semibold tracking-[2px] text-muted">언어</span>
+			<div class="mt-6 flex flex-col gap-2" role="group" aria-label="언어 설정">
+				<span class="font-mono text-xs font-semibold tracking-[2px] text-muted" aria-hidden="true"
+					>언어</span
+				>
 				<div
 					class="flex h-10 items-center border border-gray-700 px-4 font-mono text-sm text-subtle opacity-60"
 				>

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -7,7 +7,7 @@
 		onclose: () => void;
 	}
 
-	let { open = $bindable(), onclose }: Props = $props();
+	let { open, onclose }: Props = $props();
 
 	function handleBackdropClick(e: MouseEvent) {
 		if (e.target === e.currentTarget) {
@@ -22,15 +22,15 @@
 	}
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
 {#if open}
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
 		role="dialog"
 		aria-modal="true"
 		aria-label="설정"
+		tabindex="-1"
 		onclick={handleBackdropClick}
+		onkeydown={handleKeydown}
 	>
 		<div class="w-[400px] border border-gray-700 bg-bg-primary p-6">
 			<!-- Header -->

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -71,4 +71,4 @@
 	</div>
 </aside>
 
-<SettingsModal bind:open={settingsOpen} onclose={() => (settingsOpen = false)} />
+<SettingsModal open={settingsOpen} onclose={() => (settingsOpen = false)} />

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,25 +1,74 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
+	import { page } from '$app/stores';
+	import Icon from './Icon.svelte';
+	import SettingsModal from './SettingsModal.svelte';
+	import { NAV_ITEMS, FOOTER_ITEM } from './nav-config';
 
-	interface Props {
-		logo: string;
-		nav: Snippet;
-		footer?: Snippet;
+	let settingsOpen = $state(false);
+
+	function handleNavClick(item: (typeof NAV_ITEMS)[number]) {
+		if (item.action === 'SETTINGS') {
+			settingsOpen = true;
+		}
 	}
-
-	let { logo, nav, footer }: Props = $props();
 </script>
 
 <aside class="flex h-full w-20 flex-col items-center justify-between bg-accent py-8">
 	<div class="flex flex-col items-center gap-8">
-		<span class="font-display text-[28px] font-bold text-bg-primary">{logo}</span>
+		<!-- Logo -->
+		<a href="/" aria-label="홈으로 이동">
+			<img src="/favicon.svg" alt="Fantazzk" class="h-10 w-10" />
+		</a>
+
+		<!-- Navigation -->
 		<nav class="flex flex-col gap-6" aria-label="메인 네비게이션">
-			{@render nav()}
+			{#each NAV_ITEMS as item}
+				{@const isActive = item.href ? $page.url.pathname.startsWith(item.href) : false}
+				{#if item.disabled}
+					<span
+						class="flex h-12 w-12 items-center justify-center opacity-40"
+						aria-label={item.label}
+						title={item.label}
+					>
+						<Icon name={item.icon} color="#0A0A0A" />
+					</span>
+				{:else if item.href}
+					<a
+						href={item.href}
+						class="flex h-12 w-12 items-center justify-center {isActive
+							? 'rounded-sm bg-bg-primary/8'
+							: ''}"
+						aria-label={item.label}
+						aria-current={isActive ? 'page' : undefined}
+						title={item.label}
+					>
+						<Icon name={item.icon} color="#0A0A0A" />
+					</a>
+				{:else if item.action}
+					<button
+						type="button"
+						class="flex h-12 w-12 items-center justify-center"
+						aria-label={item.label}
+						title={item.label}
+						onclick={() => handleNavClick(item)}
+					>
+						<Icon name={item.icon} color="#0A0A0A" />
+					</button>
+				{/if}
+			{/each}
 		</nav>
 	</div>
-	{#if footer}
-		<div class="flex flex-col items-center">
-			{@render footer()}
-		</div>
-	{/if}
+
+	<!-- Footer -->
+	<div class="flex flex-col items-center">
+		<span
+			class="flex h-12 w-12 items-center justify-center opacity-40"
+			aria-label={FOOTER_ITEM.label}
+			title={FOOTER_ITEM.label}
+		>
+			<Icon name={FOOTER_ITEM.icon} color="#0A0A0A" />
+		</span>
+	</div>
 </aside>
+
+<SettingsModal bind:open={settingsOpen} onclose={() => (settingsOpen = false)} />

--- a/src/lib/components/ThemePicker.svelte
+++ b/src/lib/components/ThemePicker.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	let currentTheme = $state('gold');
+	import { browser } from '$app/environment';
+
+	let currentTheme = $state(
+		browser ? (document.documentElement.dataset['theme'] ?? 'gold') : 'gold'
+	);
 
 	const themes = [
 		{ name: 'gold', color: '#c9a962' },

--- a/src/lib/components/ThemePicker.svelte
+++ b/src/lib/components/ThemePicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Icon from './Icon.svelte';
+	let currentTheme = $state('gold');
 
 	const themes = [
 		{ name: 'gold', color: '#c9a962' },
@@ -9,44 +9,24 @@
 		{ name: 'orange', color: '#f97316' }
 	] as const;
 
-	let currentTheme = $state('gold');
-	let open = $state(false);
-
 	function select(name: string) {
 		currentTheme = name;
 		document.documentElement.dataset['theme'] = name;
-		open = false;
 	}
 </script>
 
-<div class="relative">
-	<button
-		class="flex h-12 w-12 items-center justify-center"
-		aria-label="테마 변경"
-		aria-expanded={open}
-		onclick={() => (open = !open)}
-	>
-		<Icon name="palette" color="#0A0A0A" />
-	</button>
-	{#if open}
-		<div
-			class="absolute bottom-0 left-16 flex gap-2 rounded-md border border-gray-700 bg-bg-elevated p-3 shadow-lg"
-			role="radiogroup"
-			aria-label="테마 선택"
-		>
-			{#each themes as t, i (i)}
-				<button
-					class="h-7 w-7 rounded-full border-2 transition-transform hover:scale-110 {currentTheme ===
-					t.name
-						? 'scale-110 border-gray-50'
-						: 'border-transparent'}"
-					style:background-color={t.color}
-					aria-label="{t.name} 테마"
-					role="radio"
-					aria-checked={currentTheme === t.name}
-					onclick={() => select(t.name)}
-				></button>
-			{/each}
-		</div>
-	{/if}
+<div class="flex gap-2" role="radiogroup" aria-label="테마 선택">
+	{#each themes as t, i (i)}
+		<button
+			class="h-7 w-7 rounded-full border-2 transition-transform hover:scale-110 {currentTheme ===
+			t.name
+				? 'scale-110 border-gray-50'
+				: 'border-transparent'}"
+			style:background-color={t.color}
+			aria-label="{t.name} 테마"
+			role="radio"
+			aria-checked={currentTheme === t.name}
+			onclick={() => select(t.name)}
+		></button>
+	{/each}
 </div>

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -8,4 +8,3 @@ export { default as ResultListItem } from './ResultListItem.svelte';
 export { default as FormField } from './FormField.svelte';
 export { default as Sidebar } from './Sidebar.svelte';
 export { default as Toggle } from './Toggle.svelte';
-export { default as SettingsModal } from './SettingsModal.svelte';

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -7,6 +7,5 @@ export { default as TemplateCard } from './TemplateCard.svelte';
 export { default as ResultListItem } from './ResultListItem.svelte';
 export { default as FormField } from './FormField.svelte';
 export { default as Sidebar } from './Sidebar.svelte';
-export { default as ThemePicker } from './ThemePicker.svelte';
 export { default as Toggle } from './Toggle.svelte';
 export { default as SettingsModal } from './SettingsModal.svelte';

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -9,3 +9,4 @@ export { default as FormField } from './FormField.svelte';
 export { default as Sidebar } from './Sidebar.svelte';
 export { default as ThemePicker } from './ThemePicker.svelte';
 export { default as Toggle } from './Toggle.svelte';
+export { default as SettingsModal } from './SettingsModal.svelte';

--- a/src/lib/components/nav-config.ts
+++ b/src/lib/components/nav-config.ts
@@ -1,0 +1,24 @@
+import type { IconName } from './Icon.svelte';
+
+export type NavActionType = 'SETTINGS';
+
+export interface NavItemType {
+	readonly icon: IconName;
+	readonly label: string;
+	readonly href?: string;
+	readonly action?: NavActionType;
+	readonly disabled?: boolean;
+}
+
+export const NAV_ITEMS: readonly NavItemType[] = [
+	{ icon: 'file-text', label: '템플릿 만들기', href: '/templates/create' },
+	{ icon: 'layout-grid', label: '대시보드', disabled: true },
+	{ icon: 'trending-up', label: '트렌드', disabled: true },
+	{ icon: 'settings', label: '설정', action: 'SETTINGS' }
+] as const;
+
+export const FOOTER_ITEM: NavItemType = {
+	icon: 'file-check',
+	label: '약관',
+	disabled: true
+} as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 	import {
 		Sidebar,
-		Icon,
 		Button,
 		Badge,
 		SectionHeader,
 		TemplateCard,
-		ResultListItem,
-		ThemePicker
+		ResultListItem
 	} from '$lib/components';
 
 	const templates = [
@@ -59,36 +57,7 @@
 
 <div class="flex h-screen bg-bg-primary">
 	<!-- Sidebar -->
-	<Sidebar logo="CD">
-		{#snippet nav()}
-			<a
-				href="/"
-				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8"
-				aria-label="대시보드"
-				aria-current="page"
-				title="대시보드"
-			>
-				<Icon name="layout-grid" color="#0A0A0A" />
-			</a>
-			<a
-				href="/templates/create"
-				class="flex h-12 w-12 items-center justify-center"
-				aria-label="템플릿 만들기"
-				title="템플릿 만들기"
-			>
-				<Icon name="file-text" color="#0A0A0A" />
-			</a>
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="트렌드">
-				<Icon name="trending-up" color="#0A0A0A" />
-			</button>
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="사용자">
-				<Icon name="users" color="#0A0A0A" />
-			</button>
-		{/snippet}
-		{#snippet footer()}
-			<ThemePicker />
-		{/snippet}
-	</Sidebar>
+	<Sidebar />
 
 	<!-- Main Content -->
 	<main class="flex flex-1 flex-col gap-10 overflow-y-auto px-14 py-12">

--- a/src/routes/lobby/[id]/+page.svelte
+++ b/src/routes/lobby/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Sidebar, Icon, Badge, ThemePicker } from '$lib/components';
+	import { Sidebar, Icon, Badge } from '$lib/components';
 
 	const room = {
 		code: 'ABC-7742',
@@ -55,42 +55,7 @@
 
 <div class="flex h-screen bg-bg-primary">
 	<!-- Sidebar -->
-	<Sidebar logo="BD">
-		{#snippet nav()}
-			<a
-				href="/"
-				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8 text-bg-primary"
-				aria-label="대시보드"
-				title="대시보드"
-			>
-				<Icon name="layout-grid" />
-			</a>
-			<button
-				type="button"
-				class="flex h-12 w-12 items-center justify-center text-bg-primary"
-				aria-label="참가자"
-			>
-				<Icon name="users" />
-			</button>
-			<button
-				type="button"
-				class="flex h-12 w-12 items-center justify-center text-bg-primary"
-				aria-label="트렌드"
-			>
-				<Icon name="trending-up" />
-			</button>
-			<button
-				type="button"
-				class="flex h-12 w-12 items-center justify-center text-bg-primary"
-				aria-label="설정"
-			>
-				<Icon name="settings" />
-			</button>
-		{/snippet}
-		{#snippet footer()}
-			<ThemePicker />
-		{/snippet}
-	</Sidebar>
+	<Sidebar />
 
 	<!-- Main Content -->
 	<main class="flex flex-1 flex-col overflow-hidden">

--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { Sidebar, Icon, Button, ThemePicker, Toggle } from '$lib/components';
+	import { Sidebar, Icon, Button, Toggle } from '$lib/components';
 	import { Template } from '$lib/domain/template';
 	import type { GameType, TemplateModeType, DraftModeType, TierType } from '$lib/domain/template';
 	import { POSITIONS_BY_GAME } from '$lib/domain/template';
@@ -117,36 +117,7 @@
 
 <div class="flex h-screen bg-bg-primary">
 	<!-- Sidebar -->
-	<Sidebar logo="MD">
-		{#snippet nav()}
-			<a
-				href="/"
-				class="flex h-12 w-12 items-center justify-center"
-				aria-label="대시보드"
-				title="대시보드"
-			>
-				<Icon name="layout-grid" color="#0A0A0A" />
-			</a>
-			<a
-				href="/templates/create"
-				class="flex h-12 w-12 items-center justify-center rounded-sm bg-bg-primary/8"
-				aria-label="템플릿 만들기"
-				aria-current="page"
-				title="템플릿 만들기"
-			>
-				<Icon name="file-text" color="#0A0A0A" />
-			</a>
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="트렌드">
-				<Icon name="trending-up" color="#0A0A0A" />
-			</button>
-			<button class="flex h-12 w-12 items-center justify-center" aria-label="사용자">
-				<Icon name="users" color="#0A0A0A" />
-			</button>
-		{/snippet}
-		{#snippet footer()}
-			<ThemePicker />
-		{/snippet}
-	</Sidebar>
+	<Sidebar />
 
 	<!-- Main -->
 	<div class="flex flex-1 flex-col">


### PR DESCRIPTION
## Summary
- 3개 페이지에서 중복 정의되던 사이드바 nav snippet을 단일 config(`nav-config.ts`)로 통합
- 사이드바 상단 텍스트 로고를 favicon 이미지 + 홈 링크로 교체
- Settings 모달 추가 (언어 선택 한국어 고정 + 테마 선택)
- 기존 ThemePicker를 사이드바에서 제거하고 Settings 모달 내부로 이동
- 사이드바 footer를 약관 아이콘(disabled)으로 교체
- Dashboard, Trends 항목 disabled 처리

closes #35