### PR TITLE
개선(template): #70 방 만들기 버튼 disabled 처리

### DIFF
--- a/src/routes/templates/create/+page.svelte
+++ b/src/routes/templates/create/+page.svelte
@@ -521,7 +521,7 @@
 				<!-- Bottom Bar -->
 				<div class="flex items-center justify-end gap-3 border-t border-gray-700 px-14 py-4">
 					<Button variant="SECONDARY" size="MD" onclick={handleSoloPlay}>혼자 하기</Button>
-					<Button variant="PRIMARY" size="MD">방 만들기</Button>
+					<Button variant="PRIMARY" size="MD" disabled>방 만들기</Button>
 				</div>
 			</main>
 


### PR DESCRIPTION
## 변경 사항

- SANDBOX 모드 우선 론칭에 따라 템플릿 생성 페이지의 "방 만들기" 버튼을 disabled 처리
- 기존 Button 컴포넌트의 disabled prop 활용 (opacity-40, cursor-not-allowed)

## 미완료 (TODO)

- [ ] 멀티플레이어 기능 구현 시 disabled 해제

## 테스트

- [x] `bun run check` 통과 (기존 타입 에러만 존재, 이번 변경과 무관)

closes #70