### PR TITLE
설정(api): OpenAPI spec 동기화

### DIFF
--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -167,6 +167,106 @@ export interface PlaceBidRequest {
 	amount: number;
 }
 
+// ─── Room Detail / Session API ───
+
+export type RoomDetailStatus = 'WAITING' | 'STARTED';
+export type RoomMode = 'DRAFT' | 'AUCTION';
+export type RoomPlayerStatus = 'AVAILABLE' | 'ASSIGNED';
+export type StartReadiness =
+	| 'WAITING_FOR_LEADERS'
+	| 'WAITING_FOR_DRAFT_POSITIONS'
+	| 'STARTABLE'
+	| 'NOT_WAITING';
+export type TeamLeaderRole = 'HOST' | 'LEADER';
+export type DraftOrderStrategy = 'SNAKE' | 'FIXED';
+
+export interface RoomDetailResponse {
+	roomCode: string;
+	status: RoomDetailStatus;
+	mode: RoomMode;
+	teamCount: number;
+	teamSize: number;
+	budget?: number;
+	minBidUnit?: number;
+	draftOrderStrategy?: DraftOrderStrategy;
+	startReadiness: StartReadiness;
+	startedGameId?: string;
+	draftOrder?: DraftOrderPreviewResponse;
+	leaders: TeamLeaderResponse[];
+	playerPool: RoomPlayerResponse[];
+}
+
+export interface RoomCreateResponse {
+	room: RoomDetailResponse;
+	teamLeaderSession: TeamLeaderSessionResponse;
+}
+
+export interface RoomJoinResponse {
+	room: RoomDetailResponse;
+	teamLeaderSession: TeamLeaderSessionResponse;
+}
+
+export interface RoomStartResponse {
+	gameId: string;
+}
+
+// ─── Game API ───
+
+export type GameStatus = 'IN_PROGRESS' | 'COMPLETED';
+
+export interface GameParticipantResponse {
+	teamLeaderId: string;
+	nickname: string;
+	draftPosition?: number;
+	remainingBudget?: number;
+}
+
+export interface GamePlayerResponse {
+	name: string;
+	position?: string;
+	displayOrder: number;
+	status: RoomPlayerStatus;
+}
+
+export interface GameMemberResponse {
+	teamLeaderId: string;
+	playerName: string;
+	assignOrder: number;
+}
+
+export interface DraftProgressResponse {
+	currentTurnIndex: number;
+	currentRound: number;
+	currentLeaderId: string;
+	currentRoundLeaderIds: string[];
+}
+
+export interface AuctionProgressResponse {
+	currentRound: number;
+	currentAuctionRoundEndsAt?: string;
+	currentAuctionTarget?: AuctionTargetResponse;
+	highestBidAmount?: number;
+	leadingLeaderId?: string;
+	bidCount?: number;
+}
+
+export interface GameDetailResponse {
+	gameId: string;
+	roomCode: string;
+	mode: RoomMode;
+	status: GameStatus;
+	teamCount: number;
+	teamSize: number;
+	budget?: number;
+	minBidUnit?: number;
+	draftOrderStrategy?: DraftOrderStrategy;
+	participants: GameParticipantResponse[];
+	playerPool: GamePlayerResponse[];
+	roster: GameMemberResponse[];
+	draftProgress?: DraftProgressResponse;
+	auctionProgress?: AuctionProgressResponse;
+}
+
 // ─── Front-only (not in OpenAPI spec) ───
 
 export interface BidRequest {

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -10,7 +10,17 @@ import type {
 	JoinableRoomResponse,
 	AuctionTargetResponse,
 	DraftOrderPreviewResponse,
-	DraftOrderSlotResponse
+	DraftOrderSlotResponse,
+	RoomDetailResponse,
+	RoomCreateResponse,
+	RoomJoinResponse,
+	RoomStartResponse,
+	GameDetailResponse,
+	GameParticipantResponse,
+	GamePlayerResponse,
+	GameMemberResponse,
+	DraftProgressResponse,
+	AuctionProgressResponse
 } from '$lib/types/api';
 
 // ─── 응답 래퍼 ───
@@ -292,6 +302,175 @@ export function createRoomSessionResponse(
 			role: 'HOST',
 			actionToken: 'mock-action-token-abc123'
 		},
+		...overrides
+	};
+}
+
+// ─── Room Detail / Session (OpenAPI) ───
+
+export function createRoomDetailResponse(
+	overrides?: Partial<RoomDetailResponse>
+): RoomDetailResponse {
+	return {
+		roomCode: 'ROOM01',
+		status: 'WAITING',
+		mode: 'DRAFT',
+		teamCount: 2,
+		teamSize: 3,
+		draftOrderStrategy: 'SNAKE',
+		startReadiness: 'WAITING_FOR_DRAFT_POSITIONS',
+		draftOrder: {
+			slots: [
+				{ draftPosition: 1, leaderId: 'leader-host', nickname: '호스트' },
+				{ draftPosition: 2, leaderId: 'leader-guest', nickname: '게스트' }
+			]
+		},
+		leaders: [
+			{ id: 'leader-host', nickname: '호스트', draftPosition: 1 },
+			{ id: 'leader-guest', nickname: '게스트', draftPosition: 2 }
+		],
+		playerPool: [
+			{ name: '선수1', position: 'TOP', displayOrder: 0, status: 'AVAILABLE' },
+			{ name: '선수2', position: 'JUNGLE', displayOrder: 1, status: 'AVAILABLE' }
+		],
+		...overrides
+	};
+}
+
+export function createRoomCreateResponse(
+	overrides?: Partial<RoomCreateResponse>
+): RoomCreateResponse {
+	return {
+		room: createRoomDetailResponse(),
+		teamLeaderSession: {
+			leaderId: 'leader-host',
+			role: 'HOST',
+			actionToken: 'room-action-token'
+		},
+		...overrides
+	};
+}
+
+export function createRoomJoinResponse(overrides?: Partial<RoomJoinResponse>): RoomJoinResponse {
+	return {
+		room: createRoomDetailResponse({
+			leaders: [
+				{ id: 'leader-host', nickname: '호스트', draftPosition: 1 },
+				{ id: 'leader-guest', nickname: '게스트' }
+			]
+		}),
+		teamLeaderSession: {
+			leaderId: 'leader-guest',
+			role: 'LEADER',
+			actionToken: 'guest-room-action-token'
+		},
+		...overrides
+	};
+}
+
+export function createRoomStartResponse(overrides?: Partial<RoomStartResponse>): RoomStartResponse {
+	return {
+		gameId: '00000000-0000-0000-0000-000000000201',
+		...overrides
+	};
+}
+
+// ─── Game ───
+
+export function createGameParticipantResponse(
+	overrides?: Partial<GameParticipantResponse>
+): GameParticipantResponse {
+	return {
+		teamLeaderId: 'leader-host',
+		nickname: '호스트',
+		draftPosition: 1,
+		...overrides
+	};
+}
+
+export function createGamePlayerResponse(
+	overrides?: Partial<GamePlayerResponse>
+): GamePlayerResponse {
+	return {
+		name: '선수1',
+		position: 'TOP',
+		displayOrder: 0,
+		status: 'AVAILABLE',
+		...overrides
+	};
+}
+
+export function createGameMemberResponse(
+	overrides?: Partial<GameMemberResponse>
+): GameMemberResponse {
+	return {
+		teamLeaderId: 'leader-host',
+		playerName: '선수1',
+		assignOrder: 0,
+		...overrides
+	};
+}
+
+export function createDraftProgressResponse(
+	overrides?: Partial<DraftProgressResponse>
+): DraftProgressResponse {
+	return {
+		currentTurnIndex: 1,
+		currentRound: 1,
+		currentLeaderId: 'leader-guest',
+		currentRoundLeaderIds: ['leader-host', 'leader-guest'],
+		...overrides
+	};
+}
+
+export function createAuctionProgressResponse(
+	overrides?: Partial<AuctionProgressResponse>
+): AuctionProgressResponse {
+	return {
+		currentRound: 2,
+		currentAuctionRoundEndsAt: '2026-04-19T12:00:45Z',
+		currentAuctionTarget: { name: '선수2', position: 'JUNGLE' },
+		highestBidAmount: 150,
+		leadingLeaderId: 'leader-guest',
+		bidCount: 2,
+		...overrides
+	};
+}
+
+export function createGameDetailResponse(
+	overrides?: Partial<GameDetailResponse>
+): GameDetailResponse {
+	return {
+		gameId: '00000000-0000-0000-0000-000000000202',
+		roomCode: 'ROOM01',
+		mode: 'DRAFT',
+		status: 'IN_PROGRESS',
+		teamCount: 2,
+		teamSize: 3,
+		draftOrderStrategy: 'SNAKE',
+		participants: [
+			createGameParticipantResponse({
+				teamLeaderId: 'leader-host',
+				nickname: '호스트',
+				draftPosition: 1
+			}),
+			createGameParticipantResponse({
+				teamLeaderId: 'leader-guest',
+				nickname: '게스트',
+				draftPosition: 2
+			})
+		],
+		playerPool: [
+			createGamePlayerResponse({ name: '선수1', displayOrder: 0, status: 'ASSIGNED' }),
+			createGamePlayerResponse({
+				name: '선수2',
+				position: 'JUNGLE',
+				displayOrder: 1,
+				status: 'AVAILABLE'
+			})
+		],
+		roster: [createGameMemberResponse({ playerName: '선수1', assignOrder: 0 })],
+		draftProgress: createDraftProgressResponse(),
 		...overrides
 	};
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,8 +6,12 @@ import {
 	createDraftTemplateDetailResponse,
 	createTemplateResponse,
 	createRoomResponse,
-	createRoomSessionResponse,
-	createJoinableRoomListResponse
+	createJoinableRoomListResponse,
+	createRoomDetailResponse,
+	createRoomCreateResponse,
+	createRoomJoinResponse,
+	createRoomStartResponse,
+	createGameDetailResponse
 } from './factories';
 
 const BASE_URL = import.meta.env['PUBLIC_API_URL'] ?? '';
@@ -38,60 +42,50 @@ export const handlers = [
 	}),
 
 	http.post(`${BASE_URL}/api/v1/rooms`, () => {
-		return HttpResponse.json(success(createRoomSessionResponse()), { status: 201 });
+		return HttpResponse.json(success(createRoomCreateResponse()), { status: 201 });
 	}),
 
 	http.get(`${BASE_URL}/api/v1/rooms/:code`, ({ params }) => {
 		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code })));
+		return HttpResponse.json(success(createRoomDetailResponse({ roomCode: code })));
 	}),
 
 	http.post(`${BASE_URL}/api/v1/rooms/:code/join`, ({ params }) => {
 		const code = params['code'] as string;
 		return HttpResponse.json(
 			success(
-				createRoomSessionResponse({
-					room: createRoomResponse({
-						code,
-						teamLeaders: [
-							{ id: 'tl-1', nickname: 'DragonSlayer', remainingBudget: 1000 },
-							{ id: 'tl-2', nickname: 'NightHawk_KR', remainingBudget: 1000 },
-							{ id: 'tl-3', nickname: '참가자', remainingBudget: 1000 }
-						]
-					})
+				createRoomJoinResponse({
+					room: createRoomDetailResponse({ roomCode: code })
 				})
 			)
 		);
 	}),
 
-	http.post(`${BASE_URL}/api/v1/rooms/:code/start`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	http.post(`${BASE_URL}/api/v1/rooms/:code/start`, () => {
+		return HttpResponse.json(success(createRoomStartResponse()));
 	}),
 
-	http.put(`${BASE_URL}/api/v1/rooms/:code/draft-position`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code })));
+	http.put(`${BASE_URL}/api/v1/rooms/:code/draft-position`, () => {
+		return HttpResponse.json(success(null));
 	}),
 
-	http.delete(`${BASE_URL}/api/v1/rooms/:code/draft-position`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code })));
+	http.delete(`${BASE_URL}/api/v1/rooms/:code/draft-position`, () => {
+		return HttpResponse.json(success(null));
 	}),
 
-	http.post(`${BASE_URL}/api/v1/rooms/:code/draft-picks`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	// ─── Game Play API ───
+
+	http.get(`${BASE_URL}/api/v1/games/:gameId`, ({ params }) => {
+		const gameId = params['gameId'] as string;
+		return HttpResponse.json(success(createGameDetailResponse({ gameId })));
 	}),
 
-	http.post(`${BASE_URL}/api/v1/rooms/:code/bids`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	http.post(`${BASE_URL}/api/v1/games/:gameId/draft-picks`, () => {
+		return HttpResponse.json(success(null));
 	}),
 
-	http.post(`${BASE_URL}/api/v1/rooms/:code/auction/progress`, ({ params }) => {
-		const code = params['code'] as string;
-		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	http.post(`${BASE_URL}/api/v1/games/:gameId/bids`, () => {
+		return HttpResponse.json(success(null));
 	}),
 
 	// ─── Solo API ───
@@ -117,6 +111,21 @@ export const handlers = [
 	}),
 
 	// ─── Front-only (not in OpenAPI spec) ───
+
+	http.post(`${BASE_URL}/api/v1/rooms/:code/draft-picks`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
+
+	http.post(`${BASE_URL}/api/v1/rooms/:code/bids`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
+
+	http.post(`${BASE_URL}/api/v1/rooms/:code/auction/progress`, ({ params }) => {
+		const code = params['code'] as string;
+		return HttpResponse.json(success(createRoomResponse({ code, status: 'IN_PROGRESS' })));
+	}),
 
 	http.post(`${BASE_URL}/api/v1/rooms/:code/bid`, ({ params }) => {
 		const code = params['code'] as string;


### PR DESCRIPTION
## sync-api-spec

### 머지된 OpenAPI PR
- #76 — chore(api): sync OpenAPI spec

### 타입 변경 (src/lib/types/api.ts)
- 추가: `RoomDetailResponse`, `RoomCreateResponse`, `RoomJoinResponse`, `RoomStartResponse`
- 추가: `GameDetailResponse`, `GameParticipantResponse`, `GamePlayerResponse`, `GameMemberResponse`
- 추가: `DraftProgressResponse`, `AuctionProgressResponse`
- 추가: 유니온 타입 `RoomDetailStatus`, `RoomMode`, `RoomPlayerStatus`, `StartReadiness`, `TeamLeaderRole`, `DraftOrderStrategy`, `GameStatus`
- 기존 `RoomResponse`, `RoomSessionResponse`, `RoomProgressResponse` 등 프론트 전용 타입은 보존

### 핸들러 변경 (src/mocks/handlers.ts)
- 추가: `GET /api/v1/games/:gameId` → `createGameDetailResponse`
- 추가: `POST /api/v1/games/:gameId/draft-picks` → `success(null)`
- 추가: `POST /api/v1/games/:gameId/bids` → `success(null)`
- 변경: `POST /rooms` → `createRoomCreateResponse` (기존 `createRoomSessionResponse`)
- 변경: `POST /rooms/:code/join` → `createRoomJoinResponse`
- 변경: `POST /rooms/:code/start` → `createRoomStartResponse` (gameId 반환)
- 변경: `GET /rooms/:code` → `createRoomDetailResponse`
- 변경: `PUT /rooms/:code/draft-position`, `DELETE /rooms/:code/draft-position` → `success(null)`
- 이동: `POST /rooms/:code/draft-picks`, `POST /rooms/:code/bids`, `POST /rooms/:code/auction/progress` 는 yaml 경로가 games 하위로 변경되어 프론트 전용 섹션으로 이전 (삭제하지 않음)

### 팩토리 변경 (src/mocks/factories.ts)
- 추가: `createRoomDetailResponse()`, `createRoomCreateResponse()`, `createRoomJoinResponse()`, `createRoomStartResponse()`
- 추가: `createGameDetailResponse()`, `createGameParticipantResponse()`, `createGamePlayerResponse()`, `createGameMemberResponse()`
- 추가: `createDraftProgressResponse()`, `createAuctionProgressResponse()`