### PR TITLE
개선(domain): #78 MarketEngine BC 도입 — SandboxBoard 도메인 설계 및 4계층 구성

### DIFF
--- a/.claude/agents/reviewer/arch.md
+++ b/.claude/agents/reviewer/arch.md
@@ -73,7 +73,7 @@ src/lib/
 market-engine/domain/<aggregate>/
 ├── <aggregate>.ts            # Aggregate Root
 ├── <vo>.ts                   # 내부 Value Object (예: bid.ts, settlement.ts)
-├── <aggregate>-repository.ts # Repository interface
+├── repository-interface.ts   # Repository interface (폴더명이 aggregate 식별)
 ├── types.ts                  # ID 타입, status 등
 ├── errors.ts
 ├── __tests__/

--- a/.claude/agents/reviewer/arch.md
+++ b/.claude/agents/reviewer/arch.md
@@ -3,29 +3,43 @@
 치지직 대회 모의 드래프트/경매 플랫폼(fantazzk)의 아키텍처 규칙을 기반으로
 워킹트리 변경사항을 리뷰하는 에이전트.
 
-## 디렉토리 구조
+## 리팩터링 진행 중 (#78)
+
+DDD 4계층 아키텍처 도입 + MarketEngine Bounded Context 정의 작업이 진행 중이다 (이슈 [#78](https://github.com/fantazzk/web-fe/issues/78)).
+
+이 문서의 **디렉토리 구조와 규칙은 목표 상태**이며, 마이그레이션이 끝날 때까지 구·신 구조가 공존한다.
+
+- **새 파일은 항상 새 구조에 따라 배치**한다.
+- 기존 파일(`src/lib/domain/{rule-engine, session, sandbox, template}/`, `src/lib/server/`)은 단계별 PR로 이전 중. 리뷰 시 이전 위치에 있는 기존 파일은 위반으로 보지 않는다 (이전 PR이 아직 진행 중).
+- 자세한 설계는 이슈 #78 본문 참조.
+
+## 디렉토리 구조 (목표 상태)
 
 ```
 src/lib/
-├── domain/        # 순수 비즈니스 로직 (UI 무관, 서버/클라이언트 공유)
-│   ├── rule-engine/   # 경매/드래프트 규칙 검증, 상태 전이
-│   ├── session/       # 세션(방) 생명주기 및 참가자 관리
-│   ├── ai/            # 솔로 모드 AI 로직
-│   └── template/      # 템플릿 스키마, 검증
-├── server/        # 서버 전용 (DB, Supabase, API 로직)
-│   ├── supabase.ts
-│   ├── realtime/
-│   └── db/
-├── features/      # UI 기능 모듈
-│   ├── auction/       # 경매 진행 화면
-│   ├── draft/         # 드래프트 진행 화면
-│   ├── lobby/         # 대기실
-│   ├── template/      # 템플릿 탐색/생성 UI
-│   └── result/        # 결과 화면, 공유 카드
-├── components/    # 공용 UI 컴포넌트
-├── stores/        # 공용 상태
-├── utils/         # 순수 헬퍼 (도메인 무관)
-└── types/         # 공유 타입
+├── core.ts                  # DDD primitives — Identity, AggregateRoot, Entity, ValueObject, Association
+│
+├── market-engine/           # Bounded Context
+│   ├── domain/
+│   │   ├── shared/          # BC 내부 공용 (Character, Team, Category, GameType, ...)
+│   │   ├── template/        # Template aggregate root + rule.ts + repository interface
+│   │   ├── auction/         # Auction aggregate + 내부 VO + repository interface
+│   │   ├── draft/           # Draft aggregate + 내부 VO + repository interface
+│   │   ├── sandbox-board/   # SandboxBoard aggregate + 내부 VO + repository interface
+│   │   └── services/        # Domain Services (cross-aggregate, 예: AuctionFactory)
+│   ├── application/         # Application Services (use case 오케스트레이션)
+│   ├── infrastructure/      # Repository 구현, Supabase·MSW 어댑터
+│   │   ├── repositories/
+│   │   └── adapters/
+│   └── presentation/        # Controllers (DTO 변환, 라우트 어댑터)
+│       ├── mappers/
+│       └── dto/
+│
+├── components/              # cross-BC UI (도메인 무관)
+├── stores/                  # cross-BC 전역 store
+├── utils/                   # 순수 헬퍼
+├── types/                   # 제너릭/유틸 타입
+└── features/                # SvelteKit UI 모듈 (이번 리팩터링 범위 외)
 ```
 
 ## 모듈 배치 규칙
@@ -34,54 +48,86 @@ src/lib/
 
 새 파일을 추가할 때 아래 순서로 판단한다:
 
-1. 아래 규칙에 명시된 위치가 있는가 → 해당 위치에 생성
+1. 아래 규칙 2의 표에 명시된 위치가 있는가 → 해당 위치에 생성
 2. 규칙에 없다면 → 비슷한 성격의 기존 모듈이 어디에 있는지 확인 → 동일 패턴으로 생성
 3. 기존 모듈도 없다면 → 사용자에게 위치 확인 후 생성
 
 ### 규칙 2: 디렉토리 선택 기준
 
-| 질문                                    | 위치               |
-| --------------------------------------- | ------------------ |
-| UI가 없는 비즈니스 로직인가?            | `domain/`          |
-| 서버에서만 실행되는 코드인가?           | `server/`          |
-| 특정 화면에 속하는 UI 코드인가?         | `features/{name}/` |
-| 2개 이상 feature에서 사용하는 UI인가?   | `components/`      |
-| 도메인과 무관한 순수 함수인가?          | `utils/`           |
-| 2개 이상 feature에서 공유하는 타입인가? | `types/`           |
+| 질문                                              | 위치                                |
+| ------------------------------------------------- | ----------------------------------- |
+| Aggregate Root / Entity / VO 신규?                | `market-engine/domain/<aggregate>/` |
+| 여러 aggregate를 걸치는 도메인 로직 (Factory 등)? | `market-engine/domain/services/`    |
+| Repository 인터페이스?                            | `market-engine/domain/<aggregate>/` |
+| Use case 오케스트레이션?                          | `market-engine/application/`        |
+| Repository 구현, Supabase·MSW 어댑터?             | `market-engine/infrastructure/`     |
+| Controller (DTO 변환·라우트 어댑터)?              | `market-engine/presentation/`       |
+| 특정 화면 전용 UI?                                | `features/<name>/`                  |
+| 2개+ feature에서 사용하는 UI?                     | `components/`                       |
+| 도메인 무관 순수 함수?                            | `utils/`                            |
+| 2개+ feature에서 공유하는 타입?                   | `types/`                            |
 
-### 규칙 3: feature 내부 구조
+### 규칙 3: aggregate 폴더 내부 구조
+
+```
+market-engine/domain/<aggregate>/
+├── <aggregate>.ts            # Aggregate Root
+├── <vo>.ts                   # 내부 Value Object (예: bid.ts, settlement.ts)
+├── <aggregate>-repository.ts # Repository interface
+├── types.ts                  # ID 타입, status 등
+├── errors.ts
+├── __tests__/
+└── index.ts                  # 외부 노출 API
+```
+
+### 규칙 4: feature 내부 구조 (변경 없음)
 
 ```
 features/{name}/
 ├── components/    # 이 feature 전용 컴포넌트
-├── server/        # 이 feature 전용 서버 로직
 ├── stores/        # 이 feature 전용 상태
 ├── utils/         # 이 feature 전용 유틸
 └── types.ts       # 이 feature 전용 타입
 ```
 
-### 규칙 4: import 경계
+### 규칙 5: 계층 의존 방향
 
-- `domain/` → UI 라이브러리(svelte 등)를 import하지 않는다. 순수 로직만 포함한다.
-- `features/A/` → `features/B/`를 직접 import하지 않는다. 공유가 필요하면 상위(`lib/`)로 승격한다.
-- `server/` 코드는 클라이언트 코드에서 직접 import하지 않는다. (`$lib/server`는 SvelteKit이 서버 전용으로 보장)
-- `components/` → `features/`를 import하지 않는다. (의존성 방향: features → components)
-- `utils/` → 다른 `lib/` 하위 모듈을 import하지 않는다. (유틸은 독립적)
+```
+presentation  →  application  →  domain
+                       ↓
+                infrastructure (구현만, interface는 domain에)
 
-### 규칙 5: 승격 규칙
+core.ts ← 모든 계층이 의존 가능 (BC 무관)
+```
 
-- feature 전용 코드가 다른 feature에서도 필요해지면 → `lib/` 공용으로 이동한다.
-- 이동 시 기존 import 경로를 모두 업데이트한다.
+**위반**:
+
+- `domain/` → `application/`, `infrastructure/`, `presentation/` 의존
+- `application/` → `presentation/` 의존
+- `application/` → `infrastructure/` **구현체** 직접 import (인터페이스만 OK)
+- `domain/` → svelte 등 UI 라이브러리
+
+### 규칙 6: import 경계 (기존 룰)
+
+- `features/A/` → `features/B/` 직접 import 금지. 공유가 필요하면 `lib/` 또는 `market-engine/`으로 승격.
+- `components/` → `features/` import 금지 (의존 방향: features → components).
+- `utils/` → 다른 `lib/` 하위 모듈 import 금지 (utils는 독립적).
+
+### 규칙 7: 승격 규칙
+
+- feature 전용 코드가 다른 feature에서도 필요해지면 → `lib/`(공용 UI)나 `market-engine/`(도메인) 적절한 위치로 이동.
+- 이동 시 기존 import 경로를 모두 업데이트.
 
 ## 리뷰 수행 방법
 
-1. `git diff --cached --name-status`로 변경된 파일 목록을 확인한다
+1. `git diff --cached --name-status`로 변경된 파일 목록을 확인한다.
 2. 새로 추가된 파일(A)에 대해:
-   - 파일 경로가 위 디렉토리 구조에 부합하는지 확인
-   - 규칙에 명시되지 않은 위치라면, 비슷한 성격의 기존 파일을 검색하여 패턴 일치 여부 확인
+   - 파일 경로가 위 디렉토리 구조에 부합하는지 확인.
+   - 규칙에 명시되지 않은 위치라면, 비슷한 성격의 기존 파일을 검색하여 패턴 일치 여부 확인.
 3. 모든 변경 파일에 대해:
-   - import 문을 검사하여 규칙 4(import 경계)를 위반하지 않는지 확인
-4. 결과를 아래 형식으로 출력한다
+   - import 문을 검사하여 규칙 5(계층 의존)와 규칙 6(import 경계)을 위반하지 않는지 확인.
+4. **마이그레이션 진행 중 예외**: `src/lib/domain/{rule-engine, session, sandbox, template}/` 또는 `src/lib/server/` 안에 있는 **기존** 파일이 단순히 그 자리에 남아있는 것은 위반이 아니다. 단, 그 파일들에 대한 **새로운 추가**(파일 신설, 새 export 추가)는 새 구조로 작성해야 한다.
+5. 결과를 아래 형식으로 출력한다.
 
 ## 출력 형식
 
@@ -96,13 +142,13 @@ PASS: 아키텍처 규칙 위반 없음
 ```
 FAIL: 아키텍처 규칙 위반 발견
 
-[위반 1] 규칙 4 위반 — features 간 직접 import
-  파일: src/lib/features/auction/components/BidPanel.svelte
-  문제: features/draft/stores/draftStore.ts를 직접 import
-  제안: 공유 상태라면 lib/stores/로 승격
+[위반 1] 규칙 5 위반 — 계층 의존 방향
+  파일: src/lib/market-engine/domain/auction/auction.ts
+  문제: $lib/market-engine/infrastructure/repositories/auction-repository를 import
+  제안: domain은 인프라에 의존하면 안 됨. Repository 인터페이스를 domain에 정의하고 그것만 의존
 
 [위반 2] 규칙 2 위반 — 잘못된 파일 위치
-  파일: src/lib/utils/calculateBid.ts
+  파일: src/lib/utils/calculate-bid.ts
   문제: 경매 입찰 계산은 도메인 로직이므로 utils/에 부적합
-  제안: src/lib/domain/rule-engine/으로 이동
+  제안: src/lib/market-engine/domain/auction/ 으로 이동
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,44 +25,75 @@ bun run lint           # Prettier + ESLint 검사
 bun run format         # Prettier 자동 포맷
 ```
 
-## 아키텍처
+## 리팩터링 진행 중 (#78)
+
+DDD 4계층 아키텍처 도입 + MarketEngine Bounded Context 정의 작업이 진행 중이다 (이슈 [#78](https://github.com/fantazzk/web-fe/issues/78)). 아래 **"아키텍처" 섹션은 목표 상태**이며, 마이그레이션이 끝날 때까지 구·신 구조가 공존한다.
+
+- **새 코드는 항상 새 구조에 따라 작성**한다 (예: 새 도메인 로직 → `src/lib/market-engine/domain/...`).
+- 기존 코드(`src/lib/domain/{rule-engine, session, sandbox, template}/`, `src/lib/server/`)는 단계별 PR로 이전 중.
+- 자세한 설계는 이슈 #78 본문 참조.
+
+## 아키텍처 (목표 상태)
 
 ```
 src/lib/
-├── domain/        # 순수 비즈니스 로직 (UI 무관, 서버/클라이언트 공유 가능)
-│   ├── rule-engine/   # 경매/드래프트 규칙 검증, 상태 전이
-│   ├── session/       # 세션(방) 생명주기 및 참가자 관리
-│   ├── ai/            # 솔로 모드 AI 입찰/픽 전략
-│   └── template/      # 템플릿 스키마, 검증
-├── server/        # 서버 전용 (Supabase, DB 쿼리, Realtime)
-├── features/      # UI 기능 모듈 (각각 components/, stores/, types.ts 포함)
-│   ├── auction/       # 경매 진행 화면
-│   ├── draft/         # 드래프트 진행 화면
-│   ├── lobby/         # 대기실 (방 생성, 참가자 목록)
-│   ├── template/      # 템플릿 탐색/생성 UI
-│   └── result/        # 결과 화면, 공유 카드
-├── components/    # 공용 UI (2개+ feature에서 사용하는 것)
-├── stores/        # 공용 상태
-├── utils/         # 순수 헬퍼 (도메인 무관)
-└── types/         # 공유 타입
+├── core.ts                  # DDD primitives — Identity, AggregateRoot, Entity, ValueObject, Association
+│
+├── market-engine/           # Bounded Context (현재 단일 BC)
+│   ├── domain/              # 비즈니스 규칙 (UI·인프라 무관)
+│   │   ├── shared/          # BC 내부 공용 (Character, Team, Category, GameType, ...)
+│   │   ├── template/        # Template aggregate
+│   │   ├── auction/         # Auction aggregate
+│   │   ├── draft/           # Draft aggregate
+│   │   ├── sandbox-board/   # SandboxBoard aggregate
+│   │   └── services/        # Domain Services (cross-aggregate, 예: Factory)
+│   ├── application/         # Application Services (use case 오케스트레이션)
+│   ├── infrastructure/      # Repository 구현, Supabase·MSW 어댑터
+│   └── presentation/        # Controllers (DTO 변환, 라우트 어댑터)
+│
+├── components/              # cross-BC UI (도메인 무관)
+├── stores/                  # cross-BC 전역 store
+├── utils/                   # 순수 헬퍼
+├── types/                   # 제너릭/유틸 타입
+└── features/                # SvelteKit UI 모듈 (이번 리팩터링 범위 외)
 ```
 
 ### 모듈 배치 규칙
 
-| 질문                   | 위치               |
-| ---------------------- | ------------------ |
-| UI 없는 비즈니스 로직? | `domain/`          |
-| 서버에서만 실행?       | `server/`          |
-| 특정 화면 전용 UI?     | `features/{name}/` |
-| 2개+ feature 공용 UI?  | `components/`      |
-| 도메인 무관 순수 함수? | `utils/`           |
+| 질문                                                   | 위치                                |
+| ------------------------------------------------------ | ----------------------------------- |
+| Aggregate Root / Entity / VO 신규 추가?                | `market-engine/domain/<aggregate>/` |
+| 여러 aggregate를 걸치는 도메인 로직 (예: Factory)?     | `market-engine/domain/services/`    |
+| Repository 인터페이스?                                 | `market-engine/domain/<aggregate>/` |
+| Use case 오케스트레이션 (load → domain method → save)? | `market-engine/application/`        |
+| Repository 구현, Supabase 어댑터?                      | `market-engine/infrastructure/`     |
+| Controller (DTO 변환·라우트 어댑터)?                   | `market-engine/presentation/`       |
+| 특정 화면 전용 UI?                                     | `features/<name>/`                  |
+| 2개+ feature 공용 UI?                                  | `components/`                       |
+| 도메인 무관 순수 함수?                                 | `utils/`                            |
 
-### import 경계 (위반 시 커밋 차단됨)
+### 계층 의존 룰 (위반 시 커밋 차단)
 
-- `domain/` → svelte import 금지 (순수 로직)
-- `features/A/` → `features/B/` 직접 import 금지 (공유 필요 시 `lib/`으로 승격)
-- `components/` → `features/` import 금지
-- `utils/` → 다른 `lib/` 모듈 import 금지
+```
+presentation  →  application  →  domain
+                       ↓
+                infrastructure (구현만, interface는 domain에)
+
+core.ts ← 모든 계층이 의존 가능 (BC 무관)
+```
+
+**금지 (계층)**:
+
+- `domain/` → `application/`, `infrastructure/`, `presentation/`
+- `application/` → `presentation/`
+- `application/` → `infrastructure/` **구현** 직접 의존 (인터페이스 import만 OK)
+- `domain/` → svelte (UI 라이브러리)
+
+**금지 (기존 룰 유지)**:
+
+- `features/A/` → `features/B/` 직접 import (공유 필요 시 `lib/`으로 승격)
+- `components/` → `features/` import
+- `utils/` → 다른 `lib/` 모듈 import
 
 자세한 규칙: `.claude/agents/reviewer/arch.md`
 

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,6 +1,6 @@
-export type Identity = string;
+type Identity = string;
 
-export abstract class AggregateRoot<Self extends AggregateRoot<Self, ID>, ID extends Identity> {
+abstract class AggregateRoot<Self extends AggregateRoot<Self, ID>, ID extends Identity> {
 	abstract readonly id: ID;
 
 	equals(other: Self): boolean {
@@ -8,7 +8,7 @@ export abstract class AggregateRoot<Self extends AggregateRoot<Self, ID>, ID ext
 	}
 }
 
-export abstract class Entity<ID extends Identity> {
+abstract class Entity<ID extends Identity> {
 	abstract readonly id: ID;
 
 	equals(other: Entity<ID>): boolean {
@@ -16,10 +16,13 @@ export abstract class Entity<ID extends Identity> {
 	}
 }
 
-export abstract class ValueObject<Self> {
+abstract class ValueObject<Self> {
 	abstract equals(other: Self): boolean;
 }
 
-export class Association<T extends AggregateRoot<T, ID>, ID extends Identity> {
+class Association<T extends AggregateRoot<T, ID>, ID extends Identity> {
 	constructor(public readonly id: ID) {}
 }
+
+export { AggregateRoot, Association, Entity, ValueObject };
+export type { Identity };

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,0 +1,25 @@
+export type Identity = string;
+
+export abstract class AggregateRoot<Self extends AggregateRoot<Self, ID>, ID extends Identity> {
+	abstract readonly id: ID;
+
+	equals(other: Self): boolean {
+		return other.id === this.id;
+	}
+}
+
+export abstract class Entity<ID extends Identity> {
+	abstract readonly id: ID;
+
+	equals(other: Entity<ID>): boolean {
+		return other.id === this.id;
+	}
+}
+
+export abstract class ValueObject<Self> {
+	abstract equals(other: Self): boolean;
+}
+
+export class Association<T extends AggregateRoot<T, ID>, ID extends Identity> {
+	constructor(public readonly id: ID) {}
+}

--- a/src/lib/market-engine/application/__tests__/sandbox-board-service.test.ts
+++ b/src/lib/market-engine/application/__tests__/sandbox-board-service.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { SandboxBoardService } from '$lib/market-engine/application/sandbox-board-service';
+import { SandboxBoard } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { SandboxBoardId } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { ISandboxBoardRepository } from '$lib/market-engine/domain/sandbox-board/repository-interface';
+import { Template } from '$lib/market-engine/domain/template/template';
+import type { TemplateId } from '$lib/market-engine/domain/template/template';
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import { Character } from '$lib/market-engine/domain/shared/character';
+import { Category } from '$lib/market-engine/domain/shared/category';
+
+// --- In-memory stubs ---
+
+class InMemoryBoardRepository implements ISandboxBoardRepository {
+	private store = new Map<SandboxBoardId, SandboxBoard>();
+
+	async findById(id: SandboxBoardId) {
+		return this.store.get(id) ?? null;
+	}
+
+	async save(board: SandboxBoard) {
+		this.store.set(board.id, board);
+	}
+}
+
+class InMemoryTemplateRepository implements ITemplateRepository {
+	constructor(private readonly template: Template) {}
+
+	async findById(_id: TemplateId) {
+		return this.template;
+	}
+
+	async findAll() {
+		return [this.template];
+	}
+
+	async save(_template: Template) {}
+}
+
+// --- Fixtures ---
+
+const S = new Category('S');
+
+const TEMPLATE = Template.restore({
+	id: 'tpl-1',
+	name: '자낳대',
+	gameType: 'LEAGUE_OF_LEGENDS',
+	creatorId: 'user-1',
+	rule: { mode: 'SANDBOX' },
+	characters: [Character.create('c1', 'Faker', 'MID', S), Character.create('c2', 'Zeus', 'TOP', S)],
+	captainsNeeded: 2,
+	creatorAsCaptain: false,
+	usageCount: 0,
+	createdAt: new Date('2026-01-01'),
+	updatedAt: new Date('2026-01-01')
+});
+
+// ---
+
+describe('SandboxBoardService', () => {
+	let boardRepo: InMemoryBoardRepository;
+	let templateRepo: InMemoryTemplateRepository;
+
+	beforeEach(() => {
+		boardRepo = new InMemoryBoardRepository();
+		templateRepo = new InMemoryTemplateRepository(TEMPLATE);
+	});
+
+	describe('create', () => {
+		it('템플릿으로부터 SandboxBoard를 생성하고 저장한다', async () => {
+			await SandboxBoardService.create(boardRepo, templateRepo, 'tpl-1', 'board-1');
+			const board = await boardRepo.findById('board-1');
+			expect(board).not.toBeNull();
+			expect(board!.templateId).toBe('tpl-1');
+			expect(board!.pool).toHaveLength(2);
+		});
+
+		it('존재하지 않는 템플릿이면 에러를 던진다', async () => {
+			const emptyRepo: ITemplateRepository = {
+				findById: async () => null,
+				findAll: async () => [],
+				save: async () => {}
+			};
+			expect(SandboxBoardService.create(boardRepo, emptyRepo, 'no-tpl', 'board-1')).rejects.toThrow(
+				'Template not found'
+			);
+		});
+	});
+
+	describe('assign', () => {
+		it('캐릭터를 감독 로스터에 배정한다', async () => {
+			await SandboxBoardService.create(boardRepo, templateRepo, 'tpl-1', 'board-1');
+			const before = await boardRepo.findById('board-1');
+			const captainId = before!.captains[0]!.id;
+
+			await SandboxBoardService.assign(boardRepo, 'board-1', 'c1', captainId);
+
+			const after = await boardRepo.findById('board-1');
+			expect(after!.rosters[captainId]).toHaveLength(1);
+			expect(after!.pool).toHaveLength(1);
+		});
+	});
+
+	describe('unassign', () => {
+		it('로스터에서 캐릭터를 pool로 되돌린다', async () => {
+			await SandboxBoardService.create(boardRepo, templateRepo, 'tpl-1', 'board-1');
+			const before = await boardRepo.findById('board-1');
+			const captainId = before!.captains[0]!.id;
+
+			await SandboxBoardService.assign(boardRepo, 'board-1', 'c1', captainId);
+			await SandboxBoardService.unassign(boardRepo, 'board-1', 'c1');
+
+			const after = await boardRepo.findById('board-1');
+			expect(after!.rosters[captainId]).toHaveLength(0);
+			expect(after!.pool).toHaveLength(2);
+		});
+	});
+
+	describe('move', () => {
+		it('캐릭터를 다른 감독 로스터로 이동한다', async () => {
+			await SandboxBoardService.create(boardRepo, templateRepo, 'tpl-1', 'board-1');
+			const before = await boardRepo.findById('board-1');
+			const cap1 = before!.captains[0]!.id;
+			const cap2 = before!.captains[1]!.id;
+
+			await SandboxBoardService.assign(boardRepo, 'board-1', 'c1', cap1);
+			await SandboxBoardService.move(boardRepo, 'board-1', 'c1', cap2);
+
+			const after = await boardRepo.findById('board-1');
+			expect(after!.rosters[cap1]).toHaveLength(0);
+			expect(after!.rosters[cap2]).toHaveLength(1);
+		});
+	});
+});

--- a/src/lib/market-engine/application/sandbox-board-service.ts
+++ b/src/lib/market-engine/application/sandbox-board-service.ts
@@ -1,0 +1,59 @@
+import type { ISandboxBoardRepository } from '$lib/market-engine/domain/sandbox-board/repository-interface';
+import type { SandboxBoardId } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { CharacterId } from '$lib/market-engine/domain/shared/character';
+import type { CaptainId } from '$lib/market-engine/domain/sandbox-board/captain';
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import type { TemplateId } from '$lib/market-engine/domain/template/template';
+import { SandboxFactory } from '$lib/market-engine/domain/services/sandbox-factory';
+
+class SandboxBoardService {
+	static async create(
+		boardRepo: ISandboxBoardRepository,
+		templateRepo: ITemplateRepository,
+		templateId: TemplateId,
+		boardId: SandboxBoardId
+	): Promise<void> {
+		const template = await templateRepo.findById(templateId);
+		if (!template) throw new Error(`Template not found: ${templateId}`);
+
+		const board = SandboxFactory.create(template, boardId);
+		await boardRepo.save(board);
+	}
+
+	static async assign(
+		repo: ISandboxBoardRepository,
+		boardId: SandboxBoardId,
+		characterId: CharacterId,
+		captainId: CaptainId
+	): Promise<void> {
+		const board = await repo.findById(boardId);
+		if (!board) throw new Error(`SandboxBoard not found: ${boardId}`);
+
+		await repo.save(board.assign(characterId, captainId));
+	}
+
+	static async unassign(
+		repo: ISandboxBoardRepository,
+		boardId: SandboxBoardId,
+		characterId: CharacterId
+	): Promise<void> {
+		const board = await repo.findById(boardId);
+		if (!board) throw new Error(`SandboxBoard not found: ${boardId}`);
+
+		await repo.save(board.unassign(characterId));
+	}
+
+	static async move(
+		repo: ISandboxBoardRepository,
+		boardId: SandboxBoardId,
+		characterId: CharacterId,
+		toCaptainId: CaptainId
+	): Promise<void> {
+		const board = await repo.findById(boardId);
+		if (!board) throw new Error(`SandboxBoard not found: ${boardId}`);
+
+		await repo.save(board.move(characterId, toCaptainId));
+	}
+}
+
+export { SandboxBoardService };

--- a/src/lib/market-engine/application/template-service.ts
+++ b/src/lib/market-engine/application/template-service.ts
@@ -1,0 +1,28 @@
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import type { Template, TemplateId } from '$lib/market-engine/domain/template/template';
+
+class TemplateService {
+	static async save(
+		apiRepo: ITemplateRepository,
+		cacheRepo: ITemplateRepository,
+		template: Template
+	): Promise<void> {
+		await apiRepo.save(template);
+		await cacheRepo.save(template);
+	}
+
+	static async findById(
+		apiRepo: ITemplateRepository,
+		cacheRepo: ITemplateRepository,
+		id: TemplateId
+	): Promise<Template | null> {
+		const cached = await cacheRepo.findById(id);
+		if (cached) return cached;
+
+		const result = await apiRepo.findById(id);
+		if (result) await cacheRepo.save(result);
+		return result;
+	}
+}
+
+export { TemplateService };

--- a/src/lib/market-engine/domain/sandbox-board/__tests__/sandbox-board.test.ts
+++ b/src/lib/market-engine/domain/sandbox-board/__tests__/sandbox-board.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'bun:test';
+import { SandboxBoard } from '../sandbox-board';
+import { SandboxBoardError } from '../errors';
+import { Character } from '../../shared/character';
+import { Category } from '../../shared/category';
+
+const S = new Category('S');
+const A = new Category('A');
+
+const CHARACTERS: Character[] = [
+	Character.create('p1', '감스트', 'TOP', S),
+	Character.create('p2', '따효니', 'MID', A),
+	Character.create('p3', '침착맨', 'ADC', S),
+	Character.create('p4', '우왁굳', 'SUPPORT', A)
+];
+
+function makeBoard(captainsCount = 2) {
+	return SandboxBoard.create({
+		id: 'board-1',
+		templateId: 'tpl-1',
+		captainsCount,
+		characters: CHARACTERS
+	});
+}
+
+describe('SandboxBoard', () => {
+	describe('create', () => {
+		it('감독 수만큼 빈 로스터가 생성된다', () => {
+			const board = makeBoard(3);
+			expect(board.captains).toHaveLength(3);
+			expect(board.captains[0]!.name).toBe('감독 1');
+			expect(board.captains[1]!.name).toBe('감독 2');
+			expect(board.captains[2]!.name).toBe('감독 3');
+			expect(board.pool).toHaveLength(4);
+			for (const captain of board.captains) {
+				expect(board.rosters[captain.id]).toEqual([]);
+			}
+		});
+
+		it('캐릭터풀에 모든 캐릭터가 포함된다', () => {
+			const board = makeBoard();
+			expect(board.pool.map((c) => c.id)).toEqual(['p1', 'p2', 'p3', 'p4']);
+		});
+	});
+
+	describe('assign', () => {
+		it('캐릭터를 pool에서 감독 로스터로 이동한다', () => {
+			const board = makeBoard();
+			const captainId = board.captains[0]!.id;
+			const next = board.assign('p1', captainId);
+			expect(next.pool).toHaveLength(3);
+			expect(next.pool.find((c) => c.id === 'p1')).toBeUndefined();
+			expect(next.rosters[captainId]).toHaveLength(1);
+			expect(next.rosters[captainId]![0]!.id).toBe('p1');
+		});
+
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = makeBoard();
+			const captainId = board.captains[0]!.id;
+			board.assign('p1', captainId);
+			expect(board.pool).toHaveLength(4);
+			expect(board.rosters[captainId]).toHaveLength(0);
+		});
+
+		it('pool에 없는 캐릭터를 assign하면 CHARACTER_NOT_IN_POOL 에러', () => {
+			const board = makeBoard();
+			const captainId = board.captains[0]!.id;
+			expect(() => board.assign('nonexistent', captainId)).toThrow(SandboxBoardError);
+			try {
+				board.assign('nonexistent', captainId);
+			} catch (e) {
+				expect((e as SandboxBoardError).code).toBe('CHARACTER_NOT_IN_POOL');
+			}
+		});
+
+		it('존재하지 않는 감독에게 assign하면 CAPTAIN_NOT_FOUND 에러', () => {
+			const board = makeBoard();
+			expect(() => board.assign('p1', 'no-captain')).toThrow(SandboxBoardError);
+			try {
+				board.assign('p1', 'no-captain');
+			} catch (e) {
+				expect((e as SandboxBoardError).code).toBe('CAPTAIN_NOT_FOUND');
+			}
+		});
+	});
+
+	describe('unassign', () => {
+		it('감독 로스터에서 pool로 복귀시킨다', () => {
+			const board = makeBoard();
+			const captainId = board.captains[0]!.id;
+			const assigned = board.assign('p1', captainId);
+			const unassigned = assigned.unassign('p1');
+			expect(unassigned.pool).toHaveLength(4);
+			expect(unassigned.pool.find((c) => c.id === 'p1')).toBeDefined();
+			expect(unassigned.rosters[captainId]).toHaveLength(0);
+		});
+
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = makeBoard();
+			const captainId = board.captains[0]!.id;
+			const assigned = board.assign('p1', captainId);
+			assigned.unassign('p1');
+			expect(assigned.rosters[captainId]).toHaveLength(1);
+			expect(assigned.pool).toHaveLength(3);
+		});
+
+		it('어느 로스터에도 없는 캐릭터는 CHARACTER_NOT_IN_ROSTER 에러', () => {
+			const board = makeBoard();
+			expect(() => board.unassign('p1')).toThrow(SandboxBoardError);
+			try {
+				board.unassign('p1');
+			} catch (e) {
+				expect((e as SandboxBoardError).code).toBe('CHARACTER_NOT_IN_ROSTER');
+			}
+		});
+	});
+
+	describe('move', () => {
+		it('한 감독 로스터에서 다른 감독 로스터로 이동한다', () => {
+			const board = makeBoard();
+			const cap1 = board.captains[0]!.id;
+			const cap2 = board.captains[1]!.id;
+			const assigned = board.assign('p1', cap1);
+			const moved = assigned.move('p1', cap2);
+			expect(moved.rosters[cap1]).toHaveLength(0);
+			expect(moved.rosters[cap2]).toHaveLength(1);
+			expect(moved.rosters[cap2]![0]!.id).toBe('p1');
+			expect(moved.pool).toHaveLength(3);
+		});
+
+		it('같은 감독으로 move하면 변경 없이 새 인스턴스 반환', () => {
+			const board = makeBoard();
+			const cap1 = board.captains[0]!.id;
+			const assigned = board.assign('p1', cap1);
+			const same = assigned.move('p1', cap1);
+			expect(same).not.toBe(assigned);
+			expect(same.rosters[cap1]).toHaveLength(1);
+		});
+
+		it('원본 보드는 변경되지 않는다 (불변)', () => {
+			const board = makeBoard();
+			const cap1 = board.captains[0]!.id;
+			const cap2 = board.captains[1]!.id;
+			const assigned = board.assign('p1', cap1);
+			assigned.move('p1', cap2);
+			expect(assigned.rosters[cap1]).toHaveLength(1);
+			expect(assigned.rosters[cap2]).toHaveLength(0);
+		});
+
+		it('로스터에 없는 캐릭터를 move하면 CHARACTER_NOT_IN_ROSTER 에러', () => {
+			const board = makeBoard();
+			const cap2 = board.captains[1]!.id;
+			expect(() => board.move('p1', cap2)).toThrow(SandboxBoardError);
+		});
+
+		it('존재하지 않는 감독으로 move하면 CAPTAIN_NOT_FOUND 에러', () => {
+			const board = makeBoard();
+			const cap1 = board.captains[0]!.id;
+			const assigned = board.assign('p1', cap1);
+			expect(() => assigned.move('p1', 'no-captain')).toThrow(SandboxBoardError);
+		});
+	});
+});

--- a/src/lib/market-engine/domain/sandbox-board/captain.ts
+++ b/src/lib/market-engine/domain/sandbox-board/captain.ts
@@ -1,0 +1,20 @@
+import type { Identity } from '$lib/core';
+import { Entity } from '$lib/core';
+
+type CaptainId = Identity;
+
+class Captain extends Entity<CaptainId> {
+	private constructor(
+		readonly id: CaptainId,
+		readonly name: string
+	) {
+		super();
+	}
+
+	static create(id: CaptainId, name: string): Captain {
+		return new Captain(id, name);
+	}
+}
+
+export { Captain };
+export type { CaptainId };

--- a/src/lib/market-engine/domain/sandbox-board/errors.ts
+++ b/src/lib/market-engine/domain/sandbox-board/errors.ts
@@ -1,0 +1,18 @@
+type SandboxBoardErrorCode =
+	| 'CHARACTER_NOT_IN_POOL'
+	| 'CHARACTER_NOT_IN_ROSTER'
+	| 'CAPTAIN_NOT_FOUND'
+	| 'DUPLICATE_ASSIGNMENT';
+
+class SandboxBoardError extends Error {
+	readonly code: SandboxBoardErrorCode;
+
+	constructor(code: SandboxBoardErrorCode, message?: string) {
+		super(message ?? code);
+		this.code = code;
+		this.name = 'SandboxBoardError';
+	}
+}
+
+export { SandboxBoardError };
+export type { SandboxBoardErrorCode };

--- a/src/lib/market-engine/domain/sandbox-board/repository-interface.ts
+++ b/src/lib/market-engine/domain/sandbox-board/repository-interface.ts
@@ -1,0 +1,11 @@
+import type {
+	SandboxBoard,
+	SandboxBoardId
+} from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+
+interface ISandboxBoardRepository {
+	findById(id: SandboxBoardId): Promise<SandboxBoard | null>;
+	save(board: SandboxBoard): Promise<void>;
+}
+
+export type { ISandboxBoardRepository };

--- a/src/lib/market-engine/domain/sandbox-board/sandbox-board.ts
+++ b/src/lib/market-engine/domain/sandbox-board/sandbox-board.ts
@@ -1,0 +1,129 @@
+import type { Identity } from '$lib/core';
+import { AggregateRoot } from '$lib/core';
+import type { Character, CharacterId } from '$lib/market-engine/domain/shared/character';
+import type { CaptainId } from '$lib/market-engine/domain/sandbox-board/captain';
+import { Captain } from '$lib/market-engine/domain/sandbox-board/captain';
+import { SandboxBoardError } from '$lib/market-engine/domain/sandbox-board/errors';
+
+type SandboxBoardId = Identity;
+type TemplateId = Identity;
+
+class SandboxBoard extends AggregateRoot<SandboxBoard, SandboxBoardId> {
+	private constructor(
+		readonly id: SandboxBoardId,
+		readonly templateId: TemplateId,
+		readonly captains: readonly Captain[],
+		readonly pool: readonly Character[],
+		readonly rosters: Readonly<Record<CaptainId, readonly Character[]>>
+	) {
+		super();
+	}
+
+	static restore(params: {
+		id: SandboxBoardId;
+		templateId: TemplateId;
+		captains: readonly Captain[];
+		pool: readonly Character[];
+		rosters: Readonly<Record<CaptainId, readonly Character[]>>;
+	}): SandboxBoard {
+		return new SandboxBoard(
+			params.id,
+			params.templateId,
+			params.captains,
+			params.pool,
+			params.rosters
+		);
+	}
+
+	static create(params: {
+		id: SandboxBoardId;
+		templateId: TemplateId;
+		captainsCount: number;
+		characters: readonly Character[];
+	}): SandboxBoard {
+		const captains = Array.from({ length: params.captainsCount }, (_, i) =>
+			Captain.create(`captain-${i + 1}`, `감독 ${i + 1}`)
+		);
+		const rosters: Record<CaptainId, readonly Character[]> = {};
+		for (const captain of captains) {
+			rosters[captain.id] = [];
+		}
+		return new SandboxBoard(
+			params.id,
+			params.templateId,
+			captains,
+			[...params.characters],
+			rosters
+		);
+	}
+
+	assign(characterId: CharacterId, toCaptainId: CaptainId): SandboxBoard {
+		if (!this.captains.some((c) => c.id === toCaptainId)) {
+			throw new SandboxBoardError('CAPTAIN_NOT_FOUND');
+		}
+		const idx = this.pool.findIndex((c) => c.id === characterId);
+		if (idx === -1) {
+			throw new SandboxBoardError('CHARACTER_NOT_IN_POOL');
+		}
+		const character = this.pool[idx]!;
+		const nextPool = [...this.pool.slice(0, idx), ...this.pool.slice(idx + 1)];
+		const nextRosters = { ...this.rosters };
+		nextRosters[toCaptainId] = [...(nextRosters[toCaptainId] ?? []), character];
+		return new SandboxBoard(this.id, this.templateId, this.captains, nextPool, nextRosters);
+	}
+
+	unassign(characterId: CharacterId): SandboxBoard {
+		let found: Character | null = null;
+		let fromCaptainId: CaptainId | null = null;
+		for (const captain of this.captains) {
+			const character = (this.rosters[captain.id] ?? []).find((c) => c.id === characterId);
+			if (character) {
+				found = character;
+				fromCaptainId = captain.id;
+				break;
+			}
+		}
+		if (!found || !fromCaptainId) {
+			throw new SandboxBoardError('CHARACTER_NOT_IN_ROSTER');
+		}
+		const nextRosters = { ...this.rosters };
+		nextRosters[fromCaptainId] = (nextRosters[fromCaptainId] ?? []).filter(
+			(c) => c.id !== characterId
+		);
+		return new SandboxBoard(
+			this.id,
+			this.templateId,
+			this.captains,
+			[...this.pool, found],
+			nextRosters
+		);
+	}
+
+	move(characterId: CharacterId, toCaptainId: CaptainId): SandboxBoard {
+		if (!this.captains.some((c) => c.id === toCaptainId)) {
+			throw new SandboxBoardError('CAPTAIN_NOT_FOUND');
+		}
+		let found: Character | null = null;
+		let fromCaptainId: CaptainId | null = null;
+		for (const captain of this.captains) {
+			const character = (this.rosters[captain.id] ?? []).find((c) => c.id === characterId);
+			if (character) {
+				found = character;
+				fromCaptainId = captain.id;
+				break;
+			}
+		}
+		if (!found || !fromCaptainId) {
+			throw new SandboxBoardError('CHARACTER_NOT_IN_ROSTER');
+		}
+		const nextRosters = { ...this.rosters };
+		nextRosters[fromCaptainId] = (nextRosters[fromCaptainId] ?? []).filter(
+			(c) => c.id !== characterId
+		);
+		nextRosters[toCaptainId] = [...(nextRosters[toCaptainId] ?? []), found];
+		return new SandboxBoard(this.id, this.templateId, this.captains, this.pool, nextRosters);
+	}
+}
+
+export { SandboxBoard };
+export type { SandboxBoardId, TemplateId };

--- a/src/lib/market-engine/domain/services/__tests__/sandbox-factory.test.ts
+++ b/src/lib/market-engine/domain/services/__tests__/sandbox-factory.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'bun:test';
+import { SandboxFactory } from '../sandbox-factory';
+import { Template } from '../../template/template';
+import { Character } from '../../shared/character';
+import { Category } from '../../shared/category';
+
+const S = new Category('S');
+
+const TEMPLATE = Template.restore({
+	id: 'tpl-1',
+	name: '자낳대',
+	gameType: 'LEAGUE_OF_LEGENDS',
+	creatorId: 'user-1',
+	rule: { mode: 'SANDBOX' },
+	characters: [
+		Character.create('c1', 'Faker', 'MID', S),
+		Character.create('c2', 'Zeus', 'TOP', S),
+		Character.create('c3', 'Oner', 'JG', S)
+	],
+	captainsNeeded: 2,
+	creatorAsCaptain: false,
+	usageCount: 0,
+	createdAt: new Date('2026-01-01'),
+	updatedAt: new Date('2026-01-01')
+});
+
+describe('SandboxFactory', () => {
+	it('템플릿으로부터 SandboxBoard를 생성한다', () => {
+		const board = SandboxFactory.create(TEMPLATE, 'board-1');
+		expect(board.id).toBe('board-1');
+		expect(board.templateId).toBe('tpl-1');
+	});
+
+	it('템플릿의 captainsNeeded만큼 감독이 생성된다', () => {
+		const board = SandboxFactory.create(TEMPLATE, 'board-1');
+		expect(board.captains).toHaveLength(2);
+	});
+
+	it('템플릿의 characters가 pool에 들어간다', () => {
+		const board = SandboxFactory.create(TEMPLATE, 'board-1');
+		expect(board.pool).toHaveLength(3);
+		expect(board.pool.map((c) => c.id)).toEqual(['c1', 'c2', 'c3']);
+	});
+
+	it('모든 로스터는 빈 상태로 초기화된다', () => {
+		const board = SandboxFactory.create(TEMPLATE, 'board-1');
+		for (const captain of board.captains) {
+			expect(board.rosters[captain.id]).toEqual([]);
+		}
+	});
+});

--- a/src/lib/market-engine/domain/services/sandbox-factory.ts
+++ b/src/lib/market-engine/domain/services/sandbox-factory.ts
@@ -1,0 +1,16 @@
+import { SandboxBoard } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { SandboxBoardId } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { Template } from '$lib/market-engine/domain/template/template';
+
+class SandboxFactory {
+	static create(template: Template, id: SandboxBoardId): SandboxBoard {
+		return SandboxBoard.create({
+			id,
+			templateId: template.id,
+			captainsCount: template.captainsNeeded,
+			characters: template.characters
+		});
+	}
+}
+
+export { SandboxFactory };

--- a/src/lib/market-engine/domain/shared/category.ts
+++ b/src/lib/market-engine/domain/shared/category.ts
@@ -1,0 +1,13 @@
+import { ValueObject } from '$lib/core';
+
+class Category extends ValueObject<Category> {
+	constructor(readonly name: string) {
+		super();
+	}
+
+	equals(other: Category): boolean {
+		return this.name === other.name;
+	}
+}
+
+export { Category };

--- a/src/lib/market-engine/domain/shared/character.ts
+++ b/src/lib/market-engine/domain/shared/character.ts
@@ -1,0 +1,28 @@
+import type { Identity } from '$lib/core';
+import { Entity } from '$lib/core';
+import type { Category } from '$lib/market-engine/domain/shared/category';
+
+type CharacterId = Identity;
+
+class Character extends Entity<CharacterId> {
+	private constructor(
+		readonly id: CharacterId,
+		readonly name: string,
+		readonly position: string | null,
+		readonly category: Category
+	) {
+		super();
+	}
+
+	static create(
+		id: CharacterId,
+		name: string,
+		position: string | null,
+		category: Category
+	): Character {
+		return new Character(id, name, position, category);
+	}
+}
+
+export { Character };
+export type { CharacterId };

--- a/src/lib/market-engine/domain/shared/game-type.ts
+++ b/src/lib/market-engine/domain/shared/game-type.ts
@@ -1,0 +1,3 @@
+type GameType = 'LEAGUE_OF_LEGENDS' | 'VALORANT' | 'OVERWATCH_2' | 'BATTLEGROUNDS';
+
+export type { GameType };

--- a/src/lib/market-engine/domain/template/__tests__/template.test.ts
+++ b/src/lib/market-engine/domain/template/__tests__/template.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import { Template } from '../template';
+import { Character } from '../../shared/character';
+import { Category } from '../../shared/category';
+
+const S = new Category('S');
+const A = new Category('A');
+
+const CHARACTERS = [
+	Character.create('c1', 'Faker', 'MID', S),
+	Character.create('c2', 'Zeus', 'TOP', A),
+	Character.create('c3', 'Oner', 'JG', A)
+];
+
+const BASE = {
+	id: 'tpl-1',
+	name: '2026 자낳대 롤 시즌1',
+	gameType: 'LEAGUE_OF_LEGENDS' as const,
+	creatorId: 'user-1',
+	characters: CHARACTERS,
+	captainsNeeded: 2,
+	creatorAsCaptain: true,
+	usageCount: 0,
+	createdAt: new Date('2026-01-01'),
+	updatedAt: new Date('2026-01-01')
+};
+
+describe('Template', () => {
+	describe('mode 파생', () => {
+		it('AUCTION rule이면 mode는 AUCTION이다', () => {
+			const template = Template.restore({
+				...BASE,
+				rule: { mode: 'AUCTION', pickBanTime: 90, totalPoints: 1000, minBidUnit: 10 }
+			});
+			expect(template.mode).toBe('AUCTION');
+		});
+
+		it('DRAFT rule이면 mode는 DRAFT이다', () => {
+			const template = Template.restore({
+				...BASE,
+				rule: { mode: 'DRAFT', pickBanTime: 60, draftMode: 'SNAKE' }
+			});
+			expect(template.mode).toBe('DRAFT');
+		});
+
+		it('SANDBOX rule이면 mode는 SANDBOX이다', () => {
+			const template = Template.restore({ ...BASE, rule: { mode: 'SANDBOX' } });
+			expect(template.mode).toBe('SANDBOX');
+		});
+	});
+
+	describe('characterCount', () => {
+		it('characters 배열 길이를 반환한다', () => {
+			const template = Template.restore({
+				...BASE,
+				rule: { mode: 'SANDBOX' }
+			});
+			expect(template.characterCount).toBe(3);
+		});
+
+		it('캐릭터가 없으면 0을 반환한다', () => {
+			const template = Template.restore({
+				...BASE,
+				characters: [],
+				rule: { mode: 'SANDBOX' }
+			});
+			expect(template.characterCount).toBe(0);
+		});
+	});
+
+	describe('rule 접근', () => {
+		it('AUCTION rule에서 totalPoints에 접근할 수 있다', () => {
+			const rule = { mode: 'AUCTION' as const, pickBanTime: 90, totalPoints: 1000, minBidUnit: 10 };
+			const template = Template.restore({ ...BASE, rule });
+			if (template.rule.mode === 'AUCTION') {
+				expect(template.rule.totalPoints).toBe(1000);
+				expect(template.rule.minBidUnit).toBe(10);
+			}
+		});
+
+		it('DRAFT rule에서 draftMode에 접근할 수 있다', () => {
+			const rule = { mode: 'DRAFT' as const, pickBanTime: 60, draftMode: 'SNAKE' as const };
+			const template = Template.restore({ ...BASE, rule });
+			if (template.rule.mode === 'DRAFT') {
+				expect(template.rule.draftMode).toBe('SNAKE');
+			}
+		});
+	});
+});

--- a/src/lib/market-engine/domain/template/repository-interface.ts
+++ b/src/lib/market-engine/domain/template/repository-interface.ts
@@ -1,0 +1,9 @@
+import type { Template, TemplateId } from '$lib/market-engine/domain/template/template';
+
+interface ITemplateRepository {
+	findById(id: TemplateId): Promise<Template | null>;
+	findAll(): Promise<Template[]>;
+	save(template: Template): Promise<void>;
+}
+
+export type { ITemplateRepository };

--- a/src/lib/market-engine/domain/template/template-rule.ts
+++ b/src/lib/market-engine/domain/template/template-rule.ts
@@ -1,0 +1,20 @@
+type AuctionRule = {
+	readonly mode: 'AUCTION';
+	readonly pickBanTime: number;
+	readonly totalPoints: number;
+	readonly minBidUnit: number;
+};
+
+type DraftRule = {
+	readonly mode: 'DRAFT';
+	readonly pickBanTime: number;
+	readonly draftMode: 'SEQUENTIAL' | 'SNAKE';
+};
+
+type SandboxRule = {
+	readonly mode: 'SANDBOX';
+};
+
+type TemplateRule = AuctionRule | DraftRule | SandboxRule;
+
+export type { AuctionRule, DraftRule, SandboxRule, TemplateRule };

--- a/src/lib/market-engine/domain/template/template.ts
+++ b/src/lib/market-engine/domain/template/template.ts
@@ -1,0 +1,89 @@
+import type { Identity } from '$lib/core';
+import { AggregateRoot } from '$lib/core';
+import type { Character } from '$lib/market-engine/domain/shared/character';
+import type { GameType } from '$lib/market-engine/domain/shared/game-type';
+import type { TemplateRule } from '$lib/market-engine/domain/template/template-rule';
+
+type TemplateId = Identity;
+
+class Template extends AggregateRoot<Template, TemplateId> {
+	private constructor(
+		readonly id: TemplateId,
+		readonly name: string,
+		readonly gameType: GameType,
+		readonly creatorId: string,
+		readonly rule: TemplateRule,
+		readonly characters: readonly Character[],
+		readonly captainsNeeded: number,
+		readonly creatorAsCaptain: boolean,
+		readonly usageCount: number,
+		readonly createdAt: Date,
+		readonly updatedAt: Date
+	) {
+		super();
+	}
+
+	get mode() {
+		return this.rule.mode;
+	}
+
+	get characterCount(): number {
+		return this.characters.length;
+	}
+
+	static create(params: {
+		id: TemplateId;
+		name: string;
+		gameType: GameType;
+		creatorId: string;
+		rule: TemplateRule;
+		characters: readonly Character[];
+		captainsNeeded: number;
+		creatorAsCaptain: boolean;
+	}): Template {
+		return new Template(
+			params.id,
+			params.name,
+			params.gameType,
+			params.creatorId,
+			params.rule,
+			params.characters,
+			params.captainsNeeded,
+			params.creatorAsCaptain,
+			0,
+			new Date(),
+			new Date()
+		);
+	}
+
+	static restore(params: {
+		id: TemplateId;
+		name: string;
+		gameType: GameType;
+		creatorId: string;
+		rule: TemplateRule;
+		characters: readonly Character[];
+		captainsNeeded: number;
+		creatorAsCaptain: boolean;
+		usageCount: number;
+		createdAt: Date;
+		updatedAt: Date;
+	}): Template {
+		return new Template(
+			params.id,
+			params.name,
+			params.gameType,
+			params.creatorId,
+			params.rule,
+			params.characters,
+			params.captainsNeeded,
+			params.creatorAsCaptain,
+			params.usageCount,
+			params.createdAt,
+			params.updatedAt
+		);
+	}
+}
+
+export { Template };
+export type { TemplateId };

--- a/src/lib/market-engine/infrastructure/sandbox-board-api-repository.ts
+++ b/src/lib/market-engine/infrastructure/sandbox-board-api-repository.ts
@@ -1,0 +1,86 @@
+import { apiGet, apiPost } from '$lib/utils/api-client';
+import type { ISandboxBoardRepository } from '$lib/market-engine/domain/sandbox-board/repository-interface';
+import { SandboxBoard } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import type { SandboxBoardId } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+import { Captain } from '$lib/market-engine/domain/sandbox-board/captain';
+import { Character } from '$lib/market-engine/domain/shared/character';
+import { Category } from '$lib/market-engine/domain/shared/category';
+
+interface SandboxBoardResponse {
+	id: string;
+	templateId: string;
+	captains: { id: string; name: string }[];
+	pool: { id: string; name: string; position: string | null; category: string }[];
+	rosters: Record<
+		string,
+		{ id: string; name: string; position: string | null; category: string }[]
+	>;
+}
+
+class SandboxBoardApiRepository implements ISandboxBoardRepository {
+	constructor(private readonly fetch: typeof globalThis.fetch) {}
+
+	async findById(id: SandboxBoardId): Promise<SandboxBoard | null> {
+		try {
+			const data = await apiGet<SandboxBoardResponse>(this.fetch, `/api/sandbox-boards/${id}`);
+			return SandboxBoardApiRepository.toDomain(data);
+		} catch {
+			return null;
+		}
+	}
+
+	async save(board: SandboxBoard): Promise<void> {
+		await apiPost(
+			this.fetch,
+			`/api/sandbox-boards/${board.id}`,
+			SandboxBoardApiRepository.toRequest(board)
+		);
+	}
+
+	private static toDomain(data: SandboxBoardResponse): SandboxBoard {
+		const captains = data.captains.map((c) => Captain.create(c.id, c.name));
+		const pool = data.pool.map((c) =>
+			Character.create(c.id, c.name, c.position, new Category(c.category))
+		);
+		const rosters: Record<string, readonly Character[]> = {};
+		for (const [captainId, chars] of Object.entries(data.rosters)) {
+			rosters[captainId] = chars.map((c) =>
+				Character.create(c.id, c.name, c.position, new Category(c.category))
+			);
+		}
+		return SandboxBoard.restore({
+			id: data.id,
+			templateId: data.templateId,
+			captains,
+			pool,
+			rosters
+		});
+	}
+
+	private static toRequest(board: SandboxBoard): SandboxBoardResponse {
+		return {
+			id: board.id,
+			templateId: board.templateId,
+			captains: board.captains.map((c) => ({ id: c.id, name: c.name })),
+			pool: board.pool.map((c) => ({
+				id: c.id,
+				name: c.name,
+				position: c.position,
+				category: c.category.name
+			})),
+			rosters: Object.fromEntries(
+				board.captains.map((c) => [
+					c.id,
+					(board.rosters[c.id] ?? []).map((ch) => ({
+						id: ch.id,
+						name: ch.name,
+						position: ch.position,
+						category: ch.category.name
+					}))
+				])
+			)
+		};
+	}
+}
+
+export { SandboxBoardApiRepository };

--- a/src/lib/market-engine/infrastructure/template-api-repository.ts
+++ b/src/lib/market-engine/infrastructure/template-api-repository.ts
@@ -1,0 +1,93 @@
+import { apiGet, apiPost } from '$lib/utils/api-client';
+import type { TemplateResponse } from '$lib/types/api';
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import { Template } from '$lib/market-engine/domain/template/template';
+import type { TemplateId } from '$lib/market-engine/domain/template/template';
+import type { TemplateRule } from '$lib/market-engine/domain/template/template-rule';
+import { Character } from '$lib/market-engine/domain/shared/character';
+import { Category } from '$lib/market-engine/domain/shared/category';
+
+class TemplateApiRepository implements ITemplateRepository {
+	constructor(private readonly fetch: typeof globalThis.fetch) {}
+
+	async findById(id: TemplateId): Promise<Template | null> {
+		try {
+			const data = await apiGet<TemplateResponse>(this.fetch, `/api/templates/${id}`);
+			return TemplateApiRepository.toDomain(data);
+		} catch {
+			return null;
+		}
+	}
+
+	async findAll(): Promise<Template[]> {
+		const data = await apiGet<TemplateResponse[]>(this.fetch, '/api/templates');
+		return data.map(TemplateApiRepository.toDomain);
+	}
+
+	async save(template: Template): Promise<void> {
+		await apiPost<TemplateResponse>(
+			this.fetch,
+			'/api/v1/templates',
+			TemplateApiRepository.toRequest(template)
+		);
+	}
+
+	private static toRequest(template: Template): Record<string, unknown> {
+		const rule = template.rule;
+		const teamCount = template.captainsNeeded;
+		const teamSize = Math.max(2, Math.floor(template.characters.length / teamCount) + 1);
+		return {
+			name: template.name,
+			gameType: template.gameType,
+			mode: rule.mode === 'AUCTION' ? 'AUCTION' : 'DRAFT',
+			teamCount,
+			teamSize,
+			players: template.characters.map((c) => ({ name: c.name, position: c.position ?? '' })),
+			...(rule.mode !== 'SANDBOX' ? { pickBanTime: rule.pickBanTime } : {}),
+			...(rule.mode === 'AUCTION' ? { budget: rule.totalPoints, minBidUnit: rule.minBidUnit } : {}),
+			...(rule.mode === 'DRAFT'
+				? { draftOrderStrategy: rule.draftMode === 'SNAKE' ? 'SNAKE' : 'FIXED' }
+				: {})
+		};
+	}
+
+	private static toDomain(row: TemplateResponse): Template {
+		const characters = (row.players ?? []).map((p, i) =>
+			Character.create(`${row.id}-c${i}`, p.name, p.position ?? null, new Category(''))
+		);
+
+		const rule = TemplateApiRepository.toRule(row);
+
+		return Template.restore({
+			id: row.id,
+			name: row.name,
+			gameType: row.gameType ?? 'LEAGUE_OF_LEGENDS',
+			creatorId: '',
+			rule,
+			characters,
+			captainsNeeded: row.teamCount,
+			creatorAsCaptain: false,
+			usageCount: 0,
+			createdAt: new Date(),
+			updatedAt: new Date()
+		});
+	}
+
+	private static toRule(row: TemplateResponse): TemplateRule {
+		if (row.mode === 'AUCTION') {
+			return {
+				mode: 'AUCTION',
+				pickBanTime: row.pickBanTime ?? 0,
+				totalPoints: row.budget ?? 0,
+				minBidUnit: row.minBidUnit ?? 0
+			};
+		}
+		return {
+			mode: 'DRAFT',
+			pickBanTime: row.pickBanTime ?? 0,
+			draftMode: row.draftOrderStrategy === 'SNAKE' ? 'SNAKE' : 'SEQUENTIAL'
+		};
+	}
+}
+
+export { TemplateApiRepository };

--- a/src/lib/market-engine/infrastructure/template-local-storage-repository.ts
+++ b/src/lib/market-engine/infrastructure/template-local-storage-repository.ts
@@ -1,0 +1,93 @@
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import { Template } from '$lib/market-engine/domain/template/template';
+import type { TemplateId } from '$lib/market-engine/domain/template/template';
+import type { TemplateRule } from '$lib/market-engine/domain/template/template-rule';
+import type { GameType } from '$lib/market-engine/domain/shared/game-type';
+import { Character } from '$lib/market-engine/domain/shared/character';
+import { Category } from '$lib/market-engine/domain/shared/category';
+
+interface TemplateLocalRow {
+	id: string;
+	name: string;
+	gameType: GameType;
+	creatorId: string;
+	rule: TemplateRule;
+	characters: { id: string; name: string; position: string | null; category: string }[];
+	captainsNeeded: number;
+	creatorAsCaptain: boolean;
+	usageCount: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const KEY_PREFIX = 'template:';
+
+class TemplateLocalStorageRepository implements ITemplateRepository {
+	async findById(id: TemplateId): Promise<Template | null> {
+		const raw = localStorage.getItem(`${KEY_PREFIX}${id}`);
+		if (!raw) return null;
+		return TemplateLocalStorageRepository.toDomain(JSON.parse(raw) as TemplateLocalRow);
+	}
+
+	async findAll(): Promise<Template[]> {
+		const templates: Template[] = [];
+		for (let i = 0; i < localStorage.length; i++) {
+			const key = localStorage.key(i);
+			if (!key?.startsWith(KEY_PREFIX)) continue;
+			const raw = localStorage.getItem(key);
+			if (raw)
+				templates.push(
+					TemplateLocalStorageRepository.toDomain(JSON.parse(raw) as TemplateLocalRow)
+				);
+		}
+		return templates;
+	}
+
+	async save(template: Template): Promise<void> {
+		localStorage.setItem(
+			`${KEY_PREFIX}${template.id}`,
+			JSON.stringify(TemplateLocalStorageRepository.toRow(template))
+		);
+	}
+
+	private static toDomain(row: TemplateLocalRow): Template {
+		return Template.restore({
+			id: row.id,
+			name: row.name,
+			gameType: row.gameType,
+			creatorId: row.creatorId,
+			rule: row.rule,
+			characters: row.characters.map((c) =>
+				Character.create(c.id, c.name, c.position, new Category(c.category))
+			),
+			captainsNeeded: row.captainsNeeded,
+			creatorAsCaptain: row.creatorAsCaptain,
+			usageCount: row.usageCount,
+			createdAt: new Date(row.createdAt),
+			updatedAt: new Date(row.updatedAt)
+		});
+	}
+
+	private static toRow(template: Template): TemplateLocalRow {
+		return {
+			id: template.id,
+			name: template.name,
+			gameType: template.gameType,
+			creatorId: template.creatorId,
+			rule: template.rule,
+			characters: template.characters.map((c) => ({
+				id: c.id,
+				name: c.name,
+				position: c.position,
+				category: c.category.name
+			})),
+			captainsNeeded: template.captainsNeeded,
+			creatorAsCaptain: template.creatorAsCaptain,
+			usageCount: template.usageCount,
+			createdAt: template.createdAt.toISOString(),
+			updatedAt: template.updatedAt.toISOString()
+		};
+	}
+}
+
+export { TemplateLocalStorageRepository };

--- a/src/lib/market-engine/presentation/sandbox-board-controller.ts
+++ b/src/lib/market-engine/presentation/sandbox-board-controller.ts
@@ -1,0 +1,93 @@
+import { SandboxBoardService } from '$lib/market-engine/application/sandbox-board-service';
+import type { ISandboxBoardRepository } from '$lib/market-engine/domain/sandbox-board/repository-interface';
+import type { ITemplateRepository } from '$lib/market-engine/domain/template/repository-interface';
+import type { SandboxBoard } from '$lib/market-engine/domain/sandbox-board/sandbox-board';
+
+interface SandboxBoardDto {
+	id: string;
+	templateId: string;
+	captains: { id: string; name: string }[];
+	pool: { id: string; name: string; position: string | null; category: string }[];
+	rosters: Record<
+		string,
+		{ id: string; name: string; position: string | null; category: string }[]
+	>;
+}
+
+class SandboxBoardController {
+	/** 템플릿을 기반으로 새 SandboxBoard를 생성한다. */
+	static async create(
+		boardRepo: ISandboxBoardRepository,
+		templateRepo: ITemplateRepository,
+		templateId: string,
+		boardId: string
+	): Promise<SandboxBoardDto> {
+		await SandboxBoardService.create(boardRepo, templateRepo, templateId, boardId);
+		const board = await boardRepo.findById(boardId);
+		return SandboxBoardController.toDto(board!);
+	}
+
+	/** pool에 있는 캐릭터를 감독 로스터에 배정한다. */
+	static async assign(
+		boardRepo: ISandboxBoardRepository,
+		boardId: string,
+		characterId: string,
+		captainId: string
+	): Promise<SandboxBoardDto> {
+		await SandboxBoardService.assign(boardRepo, boardId, characterId, captainId);
+		const board = await boardRepo.findById(boardId);
+		return SandboxBoardController.toDto(board!);
+	}
+
+	/** 감독 로스터에 있는 캐릭터를 pool로 되돌린다. */
+	static async unassign(
+		boardRepo: ISandboxBoardRepository,
+		boardId: string,
+		characterId: string
+	): Promise<SandboxBoardDto> {
+		await SandboxBoardService.unassign(boardRepo, boardId, characterId);
+		const board = await boardRepo.findById(boardId);
+		return SandboxBoardController.toDto(board!);
+	}
+
+	/** pool을 거치지 않고 캐릭터를 다른 감독 로스터로 직접 이동한다. */
+	static async move(
+		boardRepo: ISandboxBoardRepository,
+		boardId: string,
+		characterId: string,
+		toCaptainId: string
+	): Promise<SandboxBoardDto> {
+		await SandboxBoardService.move(boardRepo, boardId, characterId, toCaptainId);
+		const board = await boardRepo.findById(boardId);
+		return SandboxBoardController.toDto(board!);
+	}
+
+	/** SandboxBoard 도메인 객체를 클라이언트 응답용 DTO로 변환한다. */
+	private static toDto(board: SandboxBoard): SandboxBoardDto {
+		return {
+			id: board.id,
+			templateId: board.templateId,
+			captains: board.captains.map((c) => ({ id: c.id, name: c.name })),
+			pool: board.pool.map((c) => ({
+				id: c.id,
+				name: c.name,
+				position: c.position,
+				category: c.category.name
+			})),
+			rosters: Object.fromEntries(
+				board.captains.map((c) => [
+					c.id,
+					(board.rosters[c.id] ?? []).map((ch) => ({
+						id: ch.id,
+						name: ch.name,
+						position: ch.position,
+						category: ch.category.name
+					}))
+				])
+			)
+		};
+	}
+}
+
+export { SandboxBoardController };
+export type { SandboxBoardDto };


### PR DESCRIPTION
## Summary

MarketEngine Bounded Context를 도입하고 SandboxBoard 도메인을 DDD 4계층 아키텍처로 재구성한다.

- **Core**: `src/lib/core.ts` — Identity / AggregateRoot / Entity / ValueObject / Association
- **Domain**: `Template`(AR) + `TemplateRule`(VO), `SandboxBoard`(AR) + `Captain`(Entity), `Character`(공용 Entity), `Category`(VO), `SandboxFactory` 도메인 서비스, Repository 인터페이스
- **Application**: `SandboxBoardService` (create/assign/unassign/move), `TemplateService` (Cache-aside 패턴)
- **Infrastructure**: `TemplateApiRepository`, `TemplateLocalStorageRepository`(캐시), `SandboxBoardApiRepository`
- **Presentation**: `SandboxBoardController`

## Scope

이번 PR은 **도메인 설계 및 4계층 구조 구성에 한정**한다. UI 연결, 기존 `src/lib/domain/sandbox|template` 제거는 후속 이슈로 분리.

## 주요 설계 결정

- tier(고정 등급) → Category(사용자 정의 VO)
- Player → Character (공용 Entity)
- TemplateRule을 discriminated union (AUCTION | DRAFT | SANDBOX)
- 캐시 패턴은 Service에서 두 Repository 조율 (Spring service 스타일)
- export 컨벤션: 파일 하단 일괄 export

## Test plan

- [x] \`bun test src/lib/market-engine\` — 30 pass / 0 fail
- [x] \`bun run check\` — 새 코드 0 errors
- [ ] 후속 이슈에서 UI 통합 후 수동 e2e 검증

Closes #78