### PR TITLE
문서(arch): #83 arch.md 실제 구현(flat)에 맞춰 갱신

### DIFF
--- a/.claude/agents/reviewer/arch.md
+++ b/.claude/agents/reviewer/arch.md
@@ -22,7 +22,7 @@ src/lib/
 ├── market-engine/           # Bounded Context
 │   ├── domain/
 │   │   ├── shared/          # BC 내부 공용 (Character, Category, GameType, ...)
-│   │   ├── template/        # Template aggregate root + rule.ts + repository interface
+│   │   ├── template/        # Template aggregate root + template-rule.ts + repository interface
 │   │   ├── auction/         # Auction aggregate + 내부 VO + repository interface
 │   │   ├── draft/           # Draft aggregate + 내부 VO + repository interface
 │   │   ├── sandbox-board/   # SandboxBoard aggregate + 내부 VO + repository interface
@@ -67,12 +67,22 @@ src/lib/
 
 ```
 market-engine/domain/<aggregate>/
-├── <aggregate>.ts            # Aggregate Root (ID 타입은 여기서 export)
+├── <aggregate>.ts            # Aggregate Root (자기 ID 타입은 여기서 export)
+├── <aggregate>-rule.ts       # 도메인 규칙 VO (선택, 필요한 aggregate에만 — 예: template-rule.ts)
 ├── <vo>.ts                   # 내부 Value Object (예: bid.ts, settlement.ts)
 ├── repository-interface.ts   # Repository interface (폴더명이 aggregate 식별)
 ├── errors.ts
 └── __tests__/
 ```
+
+**Cross-aggregate ID 참조**: 다른 aggregate의 ID(예: SandboxBoard가 보유한 TemplateId)는 원본 aggregate 파일(`template/template.ts`)에서 직접 import한다. 보관 시 그대로 노출(re-export)할 수 있다.
+
+### 규칙 3-1: infrastructure / presentation 파일명 컨벤션
+
+flat 구조에서 파일명으로 소속을 식별한다.
+
+- infrastructure: `<aggregate>-<adapter>-repository.ts` (예: `template-api-repository.ts`, `template-local-storage-repository.ts`)
+- presentation: `<aggregate>-controller.ts` (예: `sandbox-board-controller.ts`)
 
 ### 규칙 4: feature 내부 구조 (변경 없음)
 

--- a/.claude/agents/reviewer/arch.md
+++ b/.claude/agents/reviewer/arch.md
@@ -21,19 +21,15 @@ src/lib/
 │
 ├── market-engine/           # Bounded Context
 │   ├── domain/
-│   │   ├── shared/          # BC 내부 공용 (Character, Team, Category, GameType, ...)
+│   │   ├── shared/          # BC 내부 공용 (Character, Category, GameType, ...)
 │   │   ├── template/        # Template aggregate root + rule.ts + repository interface
 │   │   ├── auction/         # Auction aggregate + 내부 VO + repository interface
 │   │   ├── draft/           # Draft aggregate + 내부 VO + repository interface
 │   │   ├── sandbox-board/   # SandboxBoard aggregate + 내부 VO + repository interface
-│   │   └── services/        # Domain Services (cross-aggregate, 예: AuctionFactory)
+│   │   └── services/        # Domain Services (cross-aggregate, 예: SandboxFactory)
 │   ├── application/         # Application Services (use case 오케스트레이션)
-│   ├── infrastructure/      # Repository 구현, Supabase·MSW 어댑터
-│   │   ├── repositories/
-│   │   └── adapters/
-│   └── presentation/        # Controllers (DTO 변환, 라우트 어댑터)
-│       ├── mappers/
-│       └── dto/
+│   ├── infrastructure/      # Repository 구현, Supabase·MSW 어댑터 (flat)
+│   └── presentation/        # Controllers (DTO 변환, 라우트 어댑터, flat)
 │
 ├── components/              # cross-BC UI (도메인 무관)
 ├── stores/                  # cross-BC 전역 store
@@ -71,13 +67,11 @@ src/lib/
 
 ```
 market-engine/domain/<aggregate>/
-├── <aggregate>.ts            # Aggregate Root
+├── <aggregate>.ts            # Aggregate Root (ID 타입은 여기서 export)
 ├── <vo>.ts                   # 내부 Value Object (예: bid.ts, settlement.ts)
 ├── repository-interface.ts   # Repository interface (폴더명이 aggregate 식별)
-├── types.ts                  # ID 타입, status 등
 ├── errors.ts
-├── __tests__/
-└── index.ts                  # 외부 노출 API
+└── __tests__/
 ```
 
 ### 규칙 4: feature 내부 구조 (변경 없음)
@@ -144,7 +138,7 @@ FAIL: 아키텍처 규칙 위반 발견
 
 [위반 1] 규칙 5 위반 — 계층 의존 방향
   파일: src/lib/market-engine/domain/auction/auction.ts
-  문제: $lib/market-engine/infrastructure/repositories/auction-repository를 import
+  문제: $lib/market-engine/infrastructure/auction-api-repository를 import
   제안: domain은 인프라에 의존하면 안 됨. Repository 인터페이스를 domain에 정의하고 그것만 의존
 
 [위반 2] 규칙 2 위반 — 잘못된 파일 위치


### PR DESCRIPTION
## Summary

#78 (PR #82) 머지 후 발견된 \`.claude/agents/reviewer/arch.md\` 의 실제 구현과의 불일치를 정리한다.

- infrastructure/presentation 하위 디렉토리(`repositories/`, `adapters/`, `mappers/`, `dto/`) 제거 — flat 구조로 정리
- aggregate 폴더의 `types.ts`, `index.ts` 항목 제거 — ID 타입은 AR 파일에서 export, 외부 노출 API는 직접 import로 충분
- shared의 미구현 `Team` 언급 제거 (Captain은 sandbox-board 폴더 소속)
- 위반 예시 경로를 flat 경로로 갱신
- Domain Service 예시 `AuctionFactory` → 실제 구현된 `SandboxFactory`

코드 변경 없음, 문서 단일 파일 수정.

## Test plan

- [x] 문서 단일 파일 수정 — 코드 검증 불필요
- [x] PR 자동 리뷰 통과

Closes #83