### PR TITLE
설정(ci): #88 PR 자동 테스트·린트 검증 워크플로우 도입

### DIFF
--- a/.claude/skills/jeff-pro-sync-api-spec/SKILL.md
+++ b/.claude/skills/jeff-pro-sync-api-spec/SKILL.md
@@ -83,11 +83,11 @@ git checkout dev && git pull origin dev
 
 ### 비교 대상
 
-| yaml (source of truth) | 프론트엔드 파일 |
-|-------------------------|-----------------|
-| `paths` | `src/mocks/handlers.ts` 핸들러 목록 |
-| `components.schemas` (Request/Response) | `src/lib/types/api.ts` 타입 정의 |
-| `components.schemas` (Response 기본값) | `src/mocks/factories.ts` 팩토리 함수 |
+| yaml (source of truth)                  | 프론트엔드 파일                      |
+| --------------------------------------- | ------------------------------------ |
+| `paths`                                 | `src/mocks/handlers.ts` 핸들러 목록  |
+| `components.schemas` (Request/Response) | `src/lib/types/api.ts` 타입 정의     |
+| `components.schemas` (Response 기본값)  | `src/mocks/factories.ts` 팩토리 함수 |
 
 ### diff 결과 분류
 
@@ -116,16 +116,16 @@ git checkout dev && git pull origin dev
 
 ### 타입 매핑
 
-| OpenAPI | TypeScript |
-|---------|------------|
-| `string` | `string` |
-| `string` + `format: uuid` | `string` |
-| `string` + `enum` | 리터럴 유니온 (`'A' \| 'B'`) |
-| `integer` / `int32` | `number` |
-| `boolean` | `boolean` |
-| `array` + `items.$ref` | `TypeName[]` |
-| `object` | `Record<string, unknown>` |
-| `$ref` | 참조된 타입명 |
+| OpenAPI                   | TypeScript                   |
+| ------------------------- | ---------------------------- |
+| `string`                  | `string`                     |
+| `string` + `format: uuid` | `string`                     |
+| `string` + `enum`         | 리터럴 유니온 (`'A' \| 'B'`) |
+| `integer` / `int32`       | `number`                     |
+| `boolean`                 | `boolean`                    |
+| `array` + `items.$ref`    | `TypeName[]`                 |
+| `object`                  | `Record<string, unknown>`    |
+| `$ref`                    | 참조된 타입명                |
 
 ---
 
@@ -148,10 +148,10 @@ git checkout dev && git pull origin dev
 
 ### 팩토리 함수 네이밍
 
-| 응답 형태 | 팩토리 함수명 |
-|-----------|--------------|
-| `FooResponse` | `createFooResponse()` |
-| `FooResponse[]` | `createFooListResponse()` |
+| 응답 형태                  | 팩토리 함수명               |
+| -------------------------- | --------------------------- |
+| `FooResponse`              | `createFooResponse()`       |
+| `FooResponse[]`            | `createFooListResponse()`   |
 | 상세 조회 (`:id` 파라미터) | `createFooDetailResponse()` |
 
 ---
@@ -165,11 +165,11 @@ git checkout dev && git pull origin dev
 1. 새 Response 타입마다 팩토리 함수 추가:
    ```typescript
    export function createFooResponse(overrides?: Partial<FooResponse>): FooResponse {
-     return {
-       field1: '기본값',
-       field2: 0,
-       ...overrides
-     };
+   	return {
+   		field1: '기본값',
+   		field2: 0,
+   		...overrides
+   	};
    }
    ```
 2. **기본값**: 의미 있는 더미 데이터 (선수명, 대회명 등 한글/영문), 현실적 숫자, enum은 첫 번째 값, array는 2~3개
@@ -220,17 +220,21 @@ PR 본문에 다음 형식으로 변경 사항을 작성한다:
 ## sync-api-spec
 
 ### 머지된 OpenAPI PR
+
 - #<number> — <title>
 
 ### 타입 변경 (src/lib/types/api.ts)
+
 - 추가: FooRequest, BarResponse
 - 수정: RoomResponse (draftPosition 필드 추가)
 
 ### 핸들러 변경 (src/mocks/handlers.ts)
+
 - 추가: PUT /api/v1/rooms/:code/draft-position
 - 추가: DELETE /api/v1/rooms/:code/draft-position
 
 ### 팩토리 변경 (src/mocks/factories.ts)
+
 - 추가: createRoomSessionResponse()
 - 수정: createRoomResponse() (mode, teamCount 기본값 추가)
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev, main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Sync SvelteKit ($lib alias)
+        run: bunx svelte-kit sync
+
+      - name: Run tests
+        run: bun test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run lint
+        run: bun run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ bun.lockb
 
 # Miscellaneous
 /static/
+
+# Auto-generated (backend CI source of truth)
+docs/swagger/fantazzk.yaml


### PR DESCRIPTION
## Summary

PR 생성·갱신 시 GitHub Actions로 \`bun test\`와 \`bun run lint\`를 자동 실행해 머지 차단 가능하게 한다.

## Changes

- \`.github/workflows/ci.yml\` 신설 — \`test\`, \`lint\` 두 잡
- \`pull_request\` 트리거 (opened/synchronize/reopened), 대상 브랜치 \`dev\`/\`main\`
- Bun 환경 \`oven-sh/setup-bun@v2\` 사용 + \`~/.bun/install/cache\` 캐시
- \`bun test\` 전 \`bunx svelte-kit sync\` 실행 — \`\$lib\` alias 해결을 위해 필수
- \`docs/swagger/fantazzk.yaml\`을 \`.prettierignore\`에 추가 (백엔드 자동 생성, source of truth)
- \`.claude/skills/jeff-pro-sync-api-spec/SKILL.md\` 포맷 정리

## Out of scope

- \`bun run check\` (svelte-check + tsc) 잡은 사전 존재 TS 에러 19건으로 인해 제외.
  → 후속 이슈 #90에서 정리 후 추가 예정
- branch protection rule(머지 차단 규칙)은 GitHub 저장소 설정에서 별도 적용 필요

## Test plan

로컬에서 사전 검증 완료:
- \`bun test\` — 159 pass / 0 fail
- \`bun run lint\` — exit 0
- 워크플로우 YAML 구조 검증 — jobs 4개 (jobs root + test + lint)

PR 생성 후 GitHub Actions 결과 확인 필요.

Closes #88