### PR TITLE
설정(api): OpenAPI spec 동기화

### DIFF
--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -46,14 +46,13 @@ export interface PlayerRequest {
 
 export interface CreateTemplateRequest {
 	name: string;
-	gameType: GameType;
+	gameType?: string;
 	mode: 'AUCTION' | 'DRAFT';
 	teamCount: number;
 	teamSize: number;
 	pickBanTime?: number;
 	budget?: number;
 	minBidUnit?: number;
-	positionLimit?: number;
 	draftOrderStrategy?: 'SNAKE' | 'FIXED';
 	players: PlayerRequest[];
 }
@@ -104,6 +103,7 @@ export interface RoomProgressResponse {
 
 export interface JoinableRoomResponse {
 	code: string;
+	gameType?: string;
 	mode: string;
 	teamCount: number;
 	joinedLeaderCount: number;
@@ -182,6 +182,7 @@ export type DraftOrderStrategy = 'SNAKE' | 'FIXED';
 
 export interface RoomDetailResponse {
 	roomCode: string;
+	gameType?: string;
 	status: RoomDetailStatus;
 	mode: RoomMode;
 	teamCount: number;
@@ -253,6 +254,7 @@ export interface AuctionProgressResponse {
 export interface GameDetailResponse {
 	gameId: string;
 	roomCode: string;
+	gameType?: string;
 	mode: RoomMode;
 	status: GameStatus;
 	teamCount: number;

--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -233,6 +233,7 @@ export function createJoinableRoomResponse(
 ): JoinableRoomResponse {
 	return {
 		code: 'ABC774',
+		gameType: 'LEAGUE_OF_LEGENDS',
 		mode: 'AUCTION',
 		teamCount: 8,
 		joinedLeaderCount: 3,
@@ -313,6 +314,7 @@ export function createRoomDetailResponse(
 ): RoomDetailResponse {
 	return {
 		roomCode: 'ROOM01',
+		gameType: 'LEAGUE_OF_LEGENDS',
 		status: 'WAITING',
 		mode: 'DRAFT',
 		teamCount: 2,
@@ -443,6 +445,7 @@ export function createGameDetailResponse(
 	return {
 		gameId: '00000000-0000-0000-0000-000000000202',
 		roomCode: 'ROOM01',
+		gameType: 'LEAGUE_OF_LEGENDS',
 		mode: 'DRAFT',
 		status: 'IN_PROGRESS',
 		teamCount: 2,


### PR DESCRIPTION
## sync-api-spec

### 머지된 OpenAPI PR
- #93 — chore(api): sync OpenAPI spec

### 타입 변경 (src/lib/types/api.ts)
- 수정: `CreateTemplateRequest` — `positionLimit` 필드 제거, `gameType` optional(`string?`)로 변경
- 수정: `RoomDetailResponse` — `gameType?: string` 필드 추가
- 수정: `JoinableRoomResponse` — `gameType?: string` 필드 추가
- 수정: `GameDetailResponse` — `gameType?: string` 필드 추가

### 팩토리 변경 (src/mocks/factories.ts)
- 수정: `createRoomDetailResponse()` — `gameType: 'LEAGUE_OF_LEGENDS'` 기본값 추가
- 수정: `createJoinableRoomResponse()` — `gameType: 'LEAGUE_OF_LEGENDS'` 기본값 추가
- 수정: `createGameDetailResponse()` — `gameType: 'LEAGUE_OF_LEGENDS'` 기본값 추가